### PR TITLE
Improve examples and tests

### DIFF
--- a/concat_streams_test.go
+++ b/concat_streams_test.go
@@ -8,49 +8,33 @@ import (
 )
 
 func TestConcatenatedStream(t *testing.T) {
-	ctx := context.Background()
-
-	// Create constant streams using Just
-	stream1 := Just(1, 2, 3)
-	stream2 := Just(4, 5)
-	stream3 := EmptyStream[int]()
-	stream4 := Just(6)
-	stream5 := Just(7, 8)
-
-	cStream := ConcatStreams(stream1, stream2, stream3, stream4, stream5)
-
-	// Assert the results directly
-	expected := []int{1, 2, 3, 4, 5, 6, 7, 8}
-
-	// Collect results from the concatenated Stream
-	results, err := cStream.Collect(ctx)
-	require.NoError(t, err)
-	require.EqualValues(t, expected, results)
+	// Assert the results are as expected
+	require.EqualValues(
+		t,
+		[]int{1, 2, 3, 4, 5, 6, 7, 8},
+		ConcatStreams(
+			Just(1, 2, 3),
+			Just(4, 5),
+			EmptyStream[int](),
+			Just(6),
+			Just(7, 8),
+		).MustCollect(),
+	)
 }
 
 func TestEmptyConcatenatedStream(t *testing.T) {
-	ctx := context.Background()
 
-	// Create constant streams using Just
-	// Assert the results directly
-	var expected []int
+	require.Len(t, Concat(Just(EmptyStream[int](), EmptyStream[int](), EmptyStream[int]())).MustCollect(), 0)
 
-	results, err := Concat(Just(EmptyStream[int](), EmptyStream[int](), EmptyStream[int]())).Collect(ctx)
-	require.NoError(t, err)
-	require.EqualValues(t, expected, results)
+	require.Len(t, Concat(EmptyStream[Stream[int]]()).MustCollect(), 0)
 
-	results, err = Concat(EmptyStream[Stream[int]]()).Collect(ctx)
-	require.NoError(t, err)
-	require.EqualValues(t, expected, results)
-
-	results, err = Concat(Just(EmptyStream[int]())).Collect(ctx)
-	require.NoError(t, err)
-	require.EqualValues(t, expected, results)
+	require.Len(t, Concat(Just(EmptyStream[int]())).MustCollect(), 0)
 }
 
 func TestErrorConcatenatedStream(t *testing.T) {
 	ctx := context.Background()
 
+	// Check if the error is propagated correctly
 	_, err := Concat(Just(EmptyStream[int](), NewErrorStream[int](fmt.Errorf("hi")), EmptyStream[int]())).Collect(ctx)
 	require.Error(t, err)
 

--- a/down_stream.go
+++ b/down_stream.go
@@ -7,24 +7,27 @@ type downStreamProviderFunc[S any, T any] func(ctx context.Context, srcProviderF
 func NewDownStream[S any, T any](
 	src Stream[S],
 	downStreamProviderFunc downStreamProviderFunc[S, T],
-	openFunc func(ctx context.Context, srcProviderFunc StreamProviderFunc[S]) error,
+	optOpenFunc func(ctx context.Context, srcProviderFunc StreamProviderFunc[S]) error,
+	optCloseFunc func(),
 ) Stream[T] {
-	dsLifecycle := NewStreamLifecycle(
-		func(ctx context.Context) error {
-			err := openSubStream(ctx, src)
-			if err != nil {
-				return err
-			}
-			return openFunc(ctx, src.provider)
-		}, func() {
-			closeSubStream(src)
-		})
-	return newStream[T](
+	createStreamOptions := []CreateStreamOption{WithOpenFuncOption(func(ctx context.Context) error {
+		err := openSubStream(ctx, src)
+		if err != nil {
+			return err
+		}
+		if optOpenFunc != nil {
+			return optOpenFunc(ctx, src.provider)
+		}
+		return nil
+	})}
+
+	if optCloseFunc != nil {
+		createStreamOptions = append(createStreamOptions, WithCloseFuncOption(optCloseFunc))
+	}
+	return NewSimpleStream[T](
 		func(ctx context.Context) (T, error) {
 			return downStreamProviderFunc(ctx, src.provider)
 		},
-		[]StreamLifecycle{
-			dsLifecycle,
-		},
+		createStreamOptions...,
 	)
 }

--- a/flat_map_test.go
+++ b/flat_map_test.go
@@ -1,13 +1,11 @@
 package shpanstream
 
 import (
-	"context"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestFlatMapStream(t *testing.T) {
-	ctx := context.Background()
 
 	// Define a mapper function that transforms each integer into a Stream of integers
 	mapper := func(src int) Stream[int] {
@@ -33,7 +31,5 @@ func TestFlatMapStream(t *testing.T) {
 	expected := []int{10, 11, 20, 21, 30, 31}
 
 	// Collect results from the flat-mapped Stream
-	results, err := flatMapStream.Collect(ctx)
-	require.NoError(t, err)
-	require.EqualValues(t, expected, results)
+	require.EqualValues(t, expected, flatMapStream.MustCollect())
 }

--- a/merge_streams_test.go
+++ b/merge_streams_test.go
@@ -2,53 +2,40 @@ package shpanstream
 
 import (
 	"cmp"
-	"context"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestMergedSortedStream(t *testing.T) {
-	ctx := context.Background()
-
-	// Create individual streams
-	// Merge streams
-	mergedStream := MergeSortedStreams(
-		cmp.Compare,
-		Just(1, 4, 7),
-		Just(2, 5, 8, 9),
-		EmptyStream[int](),
-		Just(3, 6, 9),
+	// Merge sorted streams and assert that the merged stream is sorted as expected
+	require.Equal(
+		t,
+		// Expected result after merging and sorting
+		[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 9},
+		MergeSortedStreams(
+			cmp.Compare,
+			Just(1, 4, 7),
+			Just(2, 5, 8, 9),
+			EmptyStream[int](),
+			Just(3, 6, 9),
+		).MustCollect(),
 	)
-
-	// Expected result after merging and sorting
-	expected := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 9}
-
-	// Collect results from the merged Stream
-	results, err := mergedStream.Collect(ctx)
-	require.NoError(t, err)
-
-	require.Equal(t, expected, results)
 }
 
 func TestMergedSortedStream_Empty(t *testing.T) {
-	ctx := context.Background()
 
-	// Merge streams
-	mergedStream := MergeSortedStreams(cmp.Compare, EmptyStream[int](), EmptyStream[int](), EmptyStream[int]())
-	// Collect results from the merged Stream
-	results, err := mergedStream.Collect(ctx)
+	// Merge Empty streams and assert that the merged stream is empty
+	require.Len(t, MergeSortedStreams(
+		cmp.Compare,
+		EmptyStream[int](),
+		EmptyStream[int](),
+		EmptyStream[int](),
+	).MustCollect(), 0)
 
-	require.NoError(t, err)
-
-	require.Len(t, results, 0)
-
-	mergedStream = MergeSortedStreams(cmp.Compare, EmptyStream[int]())
-	require.NoError(t, err)
-
-	// Collect results from the merged Stream
-	results, err = mergedStream.Collect(ctx)
-
-	require.NoError(t, err)
-
-	require.Len(t, results, 0)
+	//Just one empty stream
+	require.Len(
+		t,
+		MergeSortedStreams(cmp.Compare, EmptyStream[int]()).MustCollect(),
+		0,
+	)
 }

--- a/random_sample_test.go
+++ b/random_sample_test.go
@@ -1,7 +1,6 @@
 package shpanstream
 
 import (
-	"context"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -10,26 +9,17 @@ func TestStream_CollectRandomSample(t *testing.T) {
 	streamWith10Elements := Just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
 	// Testing we're returning all elements if sample size is bigger than the stream
-	rSample, err := streamWith10Elements.RandomSample(20).Collect(context.Background())
-	require.NoError(t, err)
-	require.Len(t, rSample, 10)
+	require.Len(t, streamWith10Elements.RandomSample(20).MustCollect(), 10)
 
 	// Testing we're returning all elements if sample size is equal to the stream
-	rSample, err = streamWith10Elements.RandomSample(10).Collect(context.Background())
-	require.NoError(t, err)
-	require.Len(t, rSample, 10)
+	require.Len(t, streamWith10Elements.RandomSample(10).MustCollect(), 10)
 
 	// Testing we're returning correct number of elements if sample size is less than the stream
-	rSample, err = streamWith10Elements.RandomSample(5).Collect(context.Background())
-	require.NoError(t, err)
-	require.Len(t, rSample, 5)
+	require.Len(t, streamWith10Elements.RandomSample(5).MustCollect(), 5)
 
 	// Testing we're returning correct number of elements if sample size is 0
-	rSample, err = streamWith10Elements.RandomSample(0).Collect(context.Background())
-	require.NoError(t, err)
-	require.Len(t, rSample, 0)
+	require.Len(t, streamWith10Elements.RandomSample(0).MustCollect(), 0)
 
-	// Testing we're returning correct number of elements if sample size is negative
 }
 
 func TestStream_CollectRandomSample_IsRandom(t *testing.T) {
@@ -38,8 +28,7 @@ func TestStream_CollectRandomSample_IsRandom(t *testing.T) {
 	// making sure it is random, theoretically it can fail, but it is very unlikely
 	foundNum := make(map[int]bool)
 	for i := 0; i < 100; i++ {
-		rSample, err := streamWith10Elements.RandomSample(5).Collect(context.Background())
-		require.NoError(t, err)
+		rSample := streamWith10Elements.RandomSample(5).MustCollect()
 		require.Len(t, rSample, 5)
 
 		for _, v := range rSample {


### PR DESCRIPTION
- cluster sorted stream uses the built-in DownStream helper instead of accessing private members
- simplify examples but using the MustCollect() convenience method