### PR TITLE
Add panic handler. Fixes #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,15 @@ stream.Map(
 	
 ```
 
-### Error propagation
+### Idiomatic Error propagation
 Streams provide a clean way to handle errors, allowing you to easily propagate errors through your data processing pipeline.
 Since streams are lazily evaluated, errors are only propagated when the stream is being materialized,
 keeping the error handling to where it is relevant
 functions that return Stream[T] doesn't have to return an error since when the stream is materialized it will be available
 this allows streams operations to be composed together without having to add boilerplate 'if err != nil' where it is not needed
 
-When there are errors, streams automatically close all the underlying resources (e.g database cursor, file...) and propagate the error to the final consumer
+When errors occur, streams automatically close all the underlying resources using the Provider Close handler (e.g database cursor, file...)
+and propagate the error to the final consumer
 
 Let's go back to the country flags example, and add error handling to the pipeline
 For simplicity, previous iteration ignored errors and used the `stream.Map` that is meant for simple mapping
@@ -180,6 +181,14 @@ func fetchCountryCodes() stream.Stream[string] {
     return stream.Just("US", "CA", "GB")
 }
 ```
+### Error propagation using "panic"
+
+While go promotes explicit error handling using return values, in code that should never fail in production, the "panic" function can be used.
+Shpanstream is not opinionated about how you should handle errors. 
+In case panic occurs throughout any stage of the pipeline, the error will be propagated to the final consumer in an idiomatic way.
+
+Especially for simple mappers and filters that should never fail, using the "panic" for those edge cases can remove a lot of boilerplate code
+in favor of a more readable and maintainable code.
 
 ### Context propagation
 When using external resources, it is important to be able to cancel the request if the stream is cancelled.

--- a/stream/shpan_stream_error_handling_test.go
+++ b/stream/shpan_stream_error_handling_test.go
@@ -1,0 +1,141 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStream_ErrorMap(t *testing.T) {
+	_, err := MapWithErr(Just(1, 2, 3, 4, 5), func(i int) (int, error) {
+		if i == 3 {
+			return 0, errors.New("test error")
+		}
+		return i, nil
+	}).Collect(context.Background())
+	require.Error(t, err)
+
+}
+
+func TestStream_PanicMap(t *testing.T) {
+	_, err := Map(Just(1, 2, 3, 4, 5), func(i int) int {
+		if i == 3 {
+			panic(errors.New("test error"))
+		}
+		return i
+	}).Collect(context.Background())
+	require.Error(t, err)
+
+}
+
+func TestStream_ErrorFilter(t *testing.T) {
+	_, err := Just(1, 2, 3, 4, 5).
+		FilterWithErr(func(i int) (bool, error) {
+
+			if i == 3 {
+				return false, errors.New("test error")
+			}
+			return i > 1, nil
+		}).
+		Collect(context.Background())
+
+	require.Error(t, err)
+
+}
+
+func TestStream_PanicFilter(t *testing.T) {
+	_, err := Just(1, 2, 3, 4, 5).
+		Filter(func(i int) bool {
+			if i == 3 {
+				panic(errors.New("test error"))
+			}
+			return i > 1
+
+		}).
+		Collect(context.Background())
+	require.Error(t, err)
+
+}
+
+func TestStream_ProviderWithError(t *testing.T) {
+	provider := &testingStreamProvider{
+		emitErrorIndex: 10,
+		emitError:      errors.New("test error"),
+	}
+	_, err := NewStream(provider).Collect(context.Background())
+	require.Error(t, err)
+	require.True(t, provider.isCloseCalled)
+	require.Equal(t, 11, provider.currEmitIndex)
+}
+
+func TestStream_ProviderWithPanic(t *testing.T) {
+	provider := &testingStreamProvider{
+		emitErrorIndex: 10,
+		emitPanic:      errors.New("test error"),
+	}
+	_, err := NewStream(provider).Collect(context.Background())
+	require.Error(t, err)
+	require.True(t, provider.isCloseCalled)
+	require.Equal(t, 11, provider.currEmitIndex)
+}
+
+func TestStream_ProviderWithOpenError(t *testing.T) {
+	provider := &testingStreamProvider{
+		openError: errors.New("open error"),
+	}
+	_, err := NewStream(provider).Collect(context.Background())
+	require.Error(t, err)
+	// Not closed, since was never opened
+	require.False(t, provider.isCloseCalled)
+	require.Equal(t, 0, provider.currEmitIndex)
+}
+
+func TestStream_ProviderWithOpenPanic(t *testing.T) {
+	provider := &testingStreamProvider{
+		openPanic: errors.New("open error"),
+	}
+	_, err := NewStream(provider).Collect(context.Background())
+	require.Error(t, err)
+	// Not closed, since was never opened
+	require.False(t, provider.isCloseCalled)
+	require.Equal(t, 0, provider.currEmitIndex)
+}
+
+type testingStreamProvider struct {
+	openError      error
+	openPanic      error
+	emitError      error
+	emitPanic      error
+	emitErrorIndex int
+	currEmitIndex  int
+	isCloseCalled  bool
+}
+
+func (t *testingStreamProvider) Open(_ context.Context) error {
+	if t.openError != nil {
+		return t.openError
+	}
+	if t.openPanic != nil {
+		panic(t.openPanic)
+	}
+	return nil
+}
+
+func (t *testingStreamProvider) Close() {
+	t.isCloseCalled = true
+}
+
+func (t *testingStreamProvider) Emit(_ context.Context) (int, error) {
+	curr := t.currEmitIndex
+	t.currEmitIndex++
+	if curr == t.emitErrorIndex {
+		if t.emitError != nil {
+			return 0, t.emitError
+		}
+		if t.emitPanic != nil {
+			panic(t.emitPanic)
+		}
+	}
+	return curr, nil
+}


### PR DESCRIPTION
Allow error propagation using "panic" at any execution stage Add tests for error handling
Update the README.md to show the panic support and advantages