### PR TITLE
Make aligner optional in ReductionDatasource using *AlignerFilter poi…

### DIFF
--- a/utils/timeseries/tsquery/datasource/reduction_datasource.go
+++ b/utils/timeseries/tsquery/datasource/reduction_datasource.go
@@ -14,7 +14,7 @@ var _ DataSource = ReductionDatasource{}
 
 type ReductionDatasource struct {
 	reductionType        tsquery.ReductionType
-	alignerFilter        AlignerFilter
+	alignerFilter        *AlignerFilter
 	multiDataSource      MultiDataSource
 	addFieldMeta         tsquery.AddFieldMeta
 	emptyDatasourceValue Value // Optional fallback when multiDataSource yields zero datasources
@@ -22,7 +22,7 @@ type ReductionDatasource struct {
 
 func NewReductionDatasource(
 	reductionType tsquery.ReductionType,
-	alignerFilter AlignerFilter,
+	alignerFilter *AlignerFilter,
 	multiDataSource MultiDataSource,
 	addFieldMeta tsquery.AddFieldMeta,
 ) *ReductionDatasource {
@@ -38,7 +38,7 @@ func NewReductionDatasource(
 // fallback value to use when the multiDataSource yields zero datasources.
 func NewReductionDatasourceWithEmptyFallback(
 	reductionType tsquery.ReductionType,
-	alignerFilter AlignerFilter,
+	alignerFilter *AlignerFilter,
 	multiDataSource MultiDataSource,
 	addFieldMeta tsquery.AddFieldMeta,
 	emptyDatasourceValue Value,
@@ -54,14 +54,13 @@ func NewReductionDatasourceWithEmptyFallback(
 
 func (r ReductionDatasource) Execute(ctx context.Context, from time.Time, to time.Time) (Result, error) {
 
-	// Validate alignment period is provided
-	if r.alignerFilter.AlignmentPeriod() == nil {
-		return util.DefaultValue[Result](), fmt.Errorf("alignment period is required for reduction datasource")
-	}
-
 	// Early validation: if emptyDatasourceValue is set, it must be a StaticValue
 	var emptyFallbackStaticValue StaticValue
 	if r.emptyDatasourceValue != nil {
+		// emptyDatasourceValue requires alignment period to generate timestamps
+		if r.alignerFilter == nil {
+			return util.DefaultValue[Result](), fmt.Errorf("alignment period is required for reduction datasource when emptyDatasourceValue is set")
+		}
 		var ok bool
 		emptyFallbackStaticValue, ok = r.emptyDatasourceValue.(StaticValue)
 		if !ok {
@@ -69,12 +68,15 @@ func (r ReductionDatasource) Execute(ctx context.Context, from time.Time, to tim
 		}
 	}
 
-	// Execute datasources and apply alignment
+	// Execute datasources, applying alignment if configured
 	datasourceResultsToToReduce, err :=
 		stream.MapWithErrAndCtx(
 			r.multiDataSource.GetDatasources(ctx),
 			func(ctx context.Context, ds DataSource) (Result, error) {
-				return NewFilteredDataSource(ds, r.alignerFilter).Execute(ctx, from, to)
+				if r.alignerFilter != nil {
+					return NewFilteredDataSource(ds, *r.alignerFilter).Execute(ctx, from, to)
+				}
+				return ds.Execute(ctx, from, to)
 			},
 		).Collect(ctx)
 

--- a/utils/timeseries/tsquery/e2e_aggregation_test.go
+++ b/utils/timeseries/tsquery/e2e_aggregation_test.go
@@ -694,7 +694,7 @@ func TestReductionDatasource_First(t *testing.T) {
 
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeFirst,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "first_value"},
 	)
@@ -720,7 +720,7 @@ func TestReductionDatasource_Last(t *testing.T) {
 
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeLast,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "last_value"},
 	)
@@ -745,7 +745,7 @@ func TestReductionDatasource_FirstLast_SingleDatasource(t *testing.T) {
 	// First with single datasource: identity optimization
 	firstDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeFirst,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -794,7 +794,7 @@ func TestReductionDatasource_AllSevenReductions(t *testing.T) {
 			multiDS := datasource.NewListMultiDatasource([]datasource.DataSource{ds1Int, ds2Int, ds3Int})
 			reductionDS := datasource.NewReductionDatasource(
 				rt,
-				datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+				alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 				multiDS,
 				tsquery.AddFieldMeta{Urn: "result"},
 			)

--- a/utils/timeseries/tsquery/e2e_filtered_multi_datasource_test.go
+++ b/utils/timeseries/tsquery/e2e_filtered_multi_datasource_test.go
@@ -55,7 +55,7 @@ func TestFilteredMultiDatasource_DeltaNonNegative_ThenReduce(t *testing.T) {
 	// Now reduce with sum using an aligner
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		filteredMultiDS,
 		tsquery.AddFieldMeta{Urn: "total_delta"},
 	)
@@ -106,10 +106,10 @@ func TestReductionDatasource_AlignerWithFillMode(t *testing.T) {
 	// Create reduction with linear fill aligner
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewInterpolatingAlignerFilter(
+		alignerFilterPtr(datasource.NewInterpolatingAlignerFilter(
 			timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC),
 			timeseries.FillModeLinear,
-		),
+		)),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "filled"},
 	)

--- a/utils/timeseries/tsquery/e2e_reduction_datasource_test.go
+++ b/utils/timeseries/tsquery/e2e_reduction_datasource_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+func alignerFilterPtr(af datasource.AlignerFilter) *datasource.AlignerFilter { return &af }
+
 // Helper function to create a single-value datasource from scalar values
 func createDatasource(t *testing.T, urn string, dataType tsquery.DataType, required bool, unit string, timestamps []time.Time, values []any) datasource.DataSource {
 	require.Equal(t, len(timestamps), len(values), "timestamps and values must have same length")
@@ -59,7 +61,7 @@ func TestReductionDatasource_SumAllDatasources_Decimal(t *testing.T) {
 	// Create a reduction datasource with 1 hour alignment
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "total"},
 	)
@@ -111,7 +113,7 @@ func TestReductionDatasource_Sum_Integer(t *testing.T) {
 	// Create reduction datasource
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "sum_counts"},
 	)
@@ -159,7 +161,7 @@ func TestReductionDatasource_AvgAllDatasources_Decimal(t *testing.T) {
 	// Create reduction datasource
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeAvg,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "average"},
 	)
@@ -199,7 +201,7 @@ func TestReductionDatasource_MinMax_Integer(t *testing.T) {
 	multiDSMin := datasource.NewListMultiDatasource([]datasource.DataSource{count1DS, count2DS})
 	reductionDSMin := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeMin,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDSMin,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -214,7 +216,7 @@ func TestReductionDatasource_MinMax_Integer(t *testing.T) {
 	multiDSMax := datasource.NewListMultiDatasource([]datasource.DataSource{count2DS, count3DS})
 	reductionDSMax := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeMax,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDSMax,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -247,7 +249,7 @@ func TestReductionDatasource_Count(t *testing.T) {
 	// Create reduction datasource
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeCount,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "datasource_count"},
 	)
@@ -289,7 +291,7 @@ func TestReductionDatasource_ErrorOnMixedDataTypes(t *testing.T) {
 	// Create reduction datasource
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -319,7 +321,7 @@ func TestReductionDatasource_ErrorOnOptionalDatasource(t *testing.T) {
 	// Create reduction datasource
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -351,7 +353,7 @@ func TestReductionDatasource_PreservesUnitWhenAllSame(t *testing.T) {
 	// Create reduction datasource
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -384,7 +386,7 @@ func TestReductionDatasource_NoUnitWhenDifferent(t *testing.T) {
 	// Create reduction datasource
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -424,7 +426,7 @@ func TestReductionDatasource_MultipleRecordsProcessedCorrectly(t *testing.T) {
 	// Create reduction datasource
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -483,7 +485,7 @@ func TestReductionDatasource_AlignsMisalignedData_Sum(t *testing.T) {
 	// Create reduction datasource with 1 hour alignment
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "total"},
 	)
@@ -544,7 +546,7 @@ func TestReductionDatasource_AlignsMisalignedData_WeightedAverage(t *testing.T) 
 	// Create reduction datasource with 1 hour alignment
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "total"},
 	)
@@ -604,7 +606,7 @@ func TestReductionDatasource_HandlesPartialOverlap(t *testing.T) {
 	// Create reduction datasource with 1 hour alignment
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "total"},
 	)
@@ -639,9 +641,9 @@ func TestReductionDatasource_HandlesPartialOverlap(t *testing.T) {
 	require.Equal(t, int64(315), records[2].Value) // 40 + 275
 }
 
-// TestReductionDatasource_ErrorOnNilAlignmentPeriod verifies that
-// a nil alignment period results in an error
-func TestReductionDatasource_ErrorOnNilAlignmentPeriod(t *testing.T) {
+// TestReductionDatasource_NoAligner verifies that a reduction datasource
+// works without an aligner when data is already aligned
+func TestReductionDatasource_NoAligner(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	timestamps := []time.Time{baseTime}
@@ -653,15 +655,44 @@ func TestReductionDatasource_ErrorOnNilAlignmentPeriod(t *testing.T) {
 
 	multiDS := datasource.NewListMultiDatasource([]datasource.DataSource{ds1, ds2})
 
-	// Create reduction datasource with nil alignment period
+	// Create reduction datasource with no aligner (nil *AlignerFilter)
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(nil), // Should error
+		nil,
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "total"},
 	)
 
-	// Execute - should fail
+	// Execute - should succeed since data is pre-aligned
+	result, err := reductionDS.Execute(ctx, time.Time{}, time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	records := result.Data().MustCollect()
+	require.Len(t, records, 1)
+	require.Equal(t, int64(30), records[0].Value)
+	require.Equal(t, baseTime, records[0].Timestamp)
+}
+
+// TestReductionDatasource_ErrorOnEmptyDatasourceValueWithoutAligner verifies that
+// emptyDatasourceValue requires an aligner (to generate aligned timestamps)
+func TestReductionDatasource_ErrorOnEmptyDatasourceValueWithoutAligner(t *testing.T) {
+	ctx := context.Background()
+
+	multiDS := datasource.NewListMultiDatasource([]datasource.DataSource{})
+
+	// Create a static fallback value
+	emptyValue := datasource.NewConstantFieldValue(tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}, int64(0))
+
+	// Create reduction datasource with emptyDatasourceValue but no aligner
+	reductionDS := datasource.NewReductionDatasourceWithEmptyFallback(
+		tsquery.ReductionTypeSum,
+		nil,
+		multiDS,
+		tsquery.AddFieldMeta{Urn: "total"},
+		emptyValue,
+	)
+
+	// Execute - should fail because emptyDatasourceValue needs alignment period
 	_, err := reductionDS.Execute(ctx, time.Time{}, time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "alignment period is required")
@@ -689,7 +720,7 @@ func TestReductionDatasource_SingleDatasource_Sum(t *testing.T) {
 	// Create reduction datasource with Sum
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeSum,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -727,7 +758,7 @@ func TestReductionDatasource_SingleDatasource_Avg(t *testing.T) {
 	// Create reduction datasource with Avg
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeAvg,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -763,7 +794,7 @@ func TestReductionDatasource_SingleDatasource_MinMax(t *testing.T) {
 	multiDSMin := datasource.NewListMultiDatasource([]datasource.DataSource{ds})
 	reductionDSMin := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeMin,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDSMin,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -780,7 +811,7 @@ func TestReductionDatasource_SingleDatasource_MinMax(t *testing.T) {
 	multiDSMax := datasource.NewListMultiDatasource([]datasource.DataSource{ds})
 	reductionDSMax := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeMax,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDSMax,
 		tsquery.AddFieldMeta{Urn: "result"},
 	)
@@ -814,7 +845,7 @@ func TestReductionDatasource_SingleDatasource_Count(t *testing.T) {
 	// Create reduction datasource with Count
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeCount,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "datasource_count"},
 	)
@@ -857,7 +888,7 @@ func TestReductionDatasource_FirstWithString(t *testing.T) {
 	// Create reduction datasource with first + 1 hour alignment
 	reductionDS := datasource.NewReductionDatasource(
 		tsquery.ReductionTypeFirst,
-		datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC)),
+		alignerFilterPtr(datasource.NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(1*time.Hour, time.UTC))),
 		multiDS,
 		tsquery.AddFieldMeta{Urn: "first_host"},
 	)

--- a/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_datasource.go
+++ b/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_datasource.go
@@ -110,10 +110,14 @@ func parseReductionDatasource(
 	pCtx *ParsingContext,
 	reductionDs ApiReductionQueryDatasource,
 ) (datasource.DataSource, error) {
-	// Parse aligner filter
-	alignerFilter, err := parseAlignerFilter(reductionDs.Aligner)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse aligner for reduction datasource: %w", err)
+	// Parse aligner filter (optional — nil means "no alignment")
+	var alignerFilter *datasource.AlignerFilter
+	if reductionDs.Aligner != nil {
+		af, err := parseAlignerFilter(*reductionDs.Aligner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse aligner for reduction datasource: %w", err)
+		}
+		alignerFilter = &af
 	}
 
 	// Parse multi datasource

--- a/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_test.go
+++ b/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_test.go
@@ -303,7 +303,7 @@ func TestParseReductionDatasource_WithPipeline(t *testing.T) {
 	// Create a reduction datasource (sum)
 	reductionDs := ApiReductionQueryDatasource{
 		ReductionType:   tsquery.ReductionTypeSum,
-		Aligner: ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
+		Aligner: &ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
 		MultiDatasource: multiDs,
 		FieldMeta: ApiAddFieldMeta{
 			Uri: "summed",
@@ -1274,7 +1274,7 @@ func TestParseDatasource_Reduction_AllTypes(t *testing.T) {
 
 			reductionDs := ApiReductionQueryDatasource{
 				ReductionType:   tt.reductionType,
-				Aligner: ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
+				Aligner: &ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
 				MultiDatasource: multiDs,
 				FieldMeta: ApiAddFieldMeta{
 					Uri: "reduced",
@@ -1348,7 +1348,7 @@ func TestParseDatasource_CustomAlignmentPeriod(t *testing.T) {
 
 	reductionDs := ApiReductionQueryDatasource{
 		ReductionType:   tsquery.ReductionTypeSum,
-		Aligner: ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
+		Aligner: &ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
 		MultiDatasource: multiDs,
 		FieldMeta: ApiAddFieldMeta{
 			Uri: "summed",
@@ -2375,7 +2375,7 @@ func TestParseFilteredMultiDatasource(t *testing.T) {
 
 	reductionDs := ApiReductionQueryDatasource{
 		ReductionType:   tsquery.ReductionTypeSum,
-		Aligner:         ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
+		Aligner:         &ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
 		MultiDatasource: filteredMultiDs,
 		FieldMeta:       ApiAddFieldMeta{Uri: "total_delta"},
 	}
@@ -2508,7 +2508,7 @@ func TestParseReductionDatasource_WithAlignerFillMode(t *testing.T) {
 	fillMode := timeseries.FillModeLinear
 	reductionDs := ApiReductionQueryDatasource{
 		ReductionType:   tsquery.ReductionTypeSum,
-		Aligner:         ApiAlignerFilter{AlignerPeriod: alignmentPeriod, FillMode: &fillMode},
+		Aligner:         &ApiAlignerFilter{AlignerPeriod: alignmentPeriod, FillMode: &fillMode},
 		MultiDatasource: multiDs,
 		FieldMeta:       ApiAddFieldMeta{Uri: "filled"},
 	}

--- a/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/tsquery-swagger.yaml
+++ b/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/tsquery-swagger.yaml
@@ -164,7 +164,6 @@ components:
       required:
         - type
         - reductionType
-        - aligner
         - multiDatasource
         - fieldMeta
       properties:
@@ -175,6 +174,10 @@ components:
         reductionType:
           $ref: '#/components/schemas/ApiReductionType'
         aligner:
+          description: |
+            Optional alignment configuration. When provided, inner datasources are aligned
+            before reduction. When omitted, data is assumed to be already aligned.
+            Required when emptyDatasourceValue is set (to generate aligned timestamps).
           $ref: '#/components/schemas/ApiAlignerFilter'
         multiDatasource:
           $ref: '#/components/schemas/ApiMultiDatasource'

--- a/utils/timeseries/tsquery/queryopenapi/codegen/testdata/extended-swagger.yaml
+++ b/utils/timeseries/tsquery/queryopenapi/codegen/testdata/extended-swagger.yaml
@@ -189,7 +189,6 @@ components:
             required:
                 - type
                 - reductionType
-                - aligner
                 - multiDatasource
                 - fieldMeta
             properties:
@@ -200,6 +199,10 @@ components:
                 reductionType:
                     $ref: '#/components/schemas/ApiReductionType'
                 aligner:
+                    description: |
+                        Optional alignment configuration. When provided, inner datasources are aligned
+                        before reduction. When omitted, data is assumed to be already aligned.
+                        Required when emptyDatasourceValue is set (to generate aligned timestamps).
                     $ref: '#/components/schemas/ApiAlignerFilter'
                 multiDatasource:
                     $ref: '#/components/schemas/ApiMultiDatasource'

--- a/utils/timeseries/tsquery/queryopenapi/openapi_generated.gen.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_generated.gen.go
@@ -862,7 +862,7 @@ type ApiReduceReportFieldValueType string
 
 // ApiReductionQueryDatasource defines model for ApiReductionQueryDatasource.
 type ApiReductionQueryDatasource struct {
-	Aligner              ApiAlignerFilter    `json:"aligner"`
+	Aligner              *ApiAlignerFilter   `json:"aligner,omitempty"`
 	EmptyDatasourceValue *ApiQueryFieldValue `json:"emptyDatasourceValue,omitempty"`
 	FieldMeta            ApiAddFieldMeta     `json:"fieldMeta"`
 

--- a/utils/timeseries/tsquery/queryopenapi/openapi_parser_datasource.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_parser_datasource.go
@@ -108,10 +108,14 @@ func parseReductionDatasource(
 	pCtx *ParsingContext,
 	reductionDs ApiReductionQueryDatasource,
 ) (datasource.DataSource, error) {
-	// Parse aligner filter
-	alignerFilter, err := parseAlignerFilter(reductionDs.Aligner)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse aligner for reduction datasource: %w", err)
+	// Parse aligner filter (optional — nil means "no alignment")
+	var alignerFilter *datasource.AlignerFilter
+	if reductionDs.Aligner != nil {
+		af, err := parseAlignerFilter(*reductionDs.Aligner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse aligner for reduction datasource: %w", err)
+		}
+		alignerFilter = &af
 	}
 
 	// Parse multi datasource

--- a/utils/timeseries/tsquery/queryopenapi/openapi_parser_test.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_parser_test.go
@@ -301,7 +301,7 @@ func TestParseReductionDatasource_WithPipeline(t *testing.T) {
 	// Create a reduction datasource (sum)
 	reductionDs := ApiReductionQueryDatasource{
 		ReductionType:   tsquery.ReductionTypeSum,
-		Aligner: ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
+		Aligner: &ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
 		MultiDatasource: multiDs,
 		FieldMeta: ApiAddFieldMeta{
 			Uri: "summed",
@@ -1272,7 +1272,7 @@ func TestParseDatasource_Reduction_AllTypes(t *testing.T) {
 
 			reductionDs := ApiReductionQueryDatasource{
 				ReductionType:   tt.reductionType,
-				Aligner: ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
+				Aligner: &ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
 				MultiDatasource: multiDs,
 				FieldMeta: ApiAddFieldMeta{
 					Uri: "reduced",
@@ -1346,7 +1346,7 @@ func TestParseDatasource_CustomAlignmentPeriod(t *testing.T) {
 
 	reductionDs := ApiReductionQueryDatasource{
 		ReductionType:   tsquery.ReductionTypeSum,
-		Aligner: ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
+		Aligner: &ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
 		MultiDatasource: multiDs,
 		FieldMeta: ApiAddFieldMeta{
 			Uri: "summed",
@@ -2373,7 +2373,7 @@ func TestParseFilteredMultiDatasource(t *testing.T) {
 
 	reductionDs := ApiReductionQueryDatasource{
 		ReductionType:   tsquery.ReductionTypeSum,
-		Aligner:         ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
+		Aligner:         &ApiAlignerFilter{AlignerPeriod: alignmentPeriod},
 		MultiDatasource: filteredMultiDs,
 		FieldMeta:       ApiAddFieldMeta{Uri: "total_delta"},
 	}
@@ -2506,7 +2506,7 @@ func TestParseReductionDatasource_WithAlignerFillMode(t *testing.T) {
 	fillMode := timeseries.FillModeLinear
 	reductionDs := ApiReductionQueryDatasource{
 		ReductionType:   tsquery.ReductionTypeSum,
-		Aligner:         ApiAlignerFilter{AlignerPeriod: alignmentPeriod, FillMode: &fillMode},
+		Aligner:         &ApiAlignerFilter{AlignerPeriod: alignmentPeriod, FillMode: &fillMode},
 		MultiDatasource: multiDs,
 		FieldMeta:       ApiAddFieldMeta{Uri: "filled"},
 	}

--- a/utils/timeseries/tsquery/queryopenapi/tsquery-swagger.yaml
+++ b/utils/timeseries/tsquery/queryopenapi/tsquery-swagger.yaml
@@ -164,7 +164,6 @@ components:
       required:
         - type
         - reductionType
-        - aligner
         - multiDatasource
         - fieldMeta
       properties:
@@ -175,6 +174,10 @@ components:
         reductionType:
           $ref: '#/components/schemas/ApiReductionType'
         aligner:
+          description: |
+            Optional alignment configuration. When provided, inner datasources are aligned
+            before reduction. When omitted, data is assumed to be already aligned.
+            Required when emptyDatasourceValue is set (to generate aligned timestamps).
           $ref: '#/components/schemas/ApiAlignerFilter'
         multiDatasource:
           $ref: '#/components/schemas/ApiMultiDatasource'


### PR DESCRIPTION
…nter

Use *AlignerFilter instead of zero-value AlignerFilter{} to represent "no alignment", making optionality explicit at the type level. This prevents potential misuse of a zero-value AlignerFilter whose Filter() would panic, and aligns with the swagger spec where aligner is optional.