### PR TITLE
Add MatchesDay, ActiveWindows, and MatchesPeriod to Schedule

### DIFF
--- a/utils/timeseries/tsquery/datasource/schedule.go
+++ b/utils/timeseries/tsquery/datasource/schedule.go
@@ -1,8 +1,12 @@
 package datasource
 
 import (
+	"context"
 	"fmt"
+	"iter"
 	"time"
+
+	"github.com/shpandrak/shpanstream/stream"
 )
 
 // ScheduleTimeSlot holds pre-computed minute-of-day boundaries for fast comparison.
@@ -269,6 +273,206 @@ func conditionMatches(cond *ScheduleCondition, localTime time.Time) bool {
 	}
 
 	return true
+}
+
+// MatchesDay reports whether the given date falls within the schedule,
+// ignoring time-of-day (time-slot) constraints. Only day-level fields are
+// checked: schedule bounds (day-level), weekday, period, dates, and excludes.
+// The time component of date is used only for timezone conversion to determine
+// the calendar date in the schedule's timezone.
+func (s Schedule) MatchesDay(date time.Time) bool {
+	// Convert to schedule timezone and extract the calendar date.
+	localTime := date.In(s.location)
+	dayStart := time.Date(localTime.Year(), localTime.Month(), localTime.Day(), 0, 0, 0, 0, s.location)
+	dayEnd := dayStart.AddDate(0, 0, 1)
+
+	// Day-level bounds check: does this calendar day overlap with [startTime, endTime)?
+	if s.startTime != nil && !dayEnd.After(*s.startTime) {
+		return false
+	}
+	if s.endTime != nil && !dayStart.Before(*s.endTime) {
+		return false
+	}
+
+	// At least one include condition must match at day level (no conditions → no match)
+	matched := false
+	for i := range s.conditions {
+		if conditionMatchesDay(&s.conditions[i], localTime) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false
+	}
+
+	// No exclude condition may fully exclude this day.
+	// An exclude condition with time-slots only excludes specific hours, not the
+	// entire day, so we skip it here — it can only reduce ActiveWindows, not
+	// eliminate the day.
+	for i := range s.excludeConditions {
+		if len(s.excludeConditions[i].timeSlots) > 0 {
+			continue
+		}
+		if conditionMatchesDay(&s.excludeConditions[i], localTime) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// conditionMatchesDay checks if a single condition matches the given local time
+// at the day level (ignoring time-slot constraints).
+// All specified day-level field-types are AND'd; items within a field-type are OR'd.
+func conditionMatchesDay(cond *ScheduleCondition, localTime time.Time) bool {
+	// Day of week check (AND)
+	if cond.hasDaysOfWeek && !cond.daysOfWeek[localTime.Weekday()] {
+		return false
+	}
+
+	// Period check (OR across periods, AND with other fields)
+	if len(cond.periods) > 0 {
+		month := int(localTime.Month())
+		day := localTime.Day()
+		matched := false
+		for i := range cond.periods {
+			if periodMatches(&cond.periods[i], month, day) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	// Date check (AND with other fields)
+	if len(cond.dates) > 0 {
+		dateStr := localTime.Format("2006-01-02")
+		if !cond.dates[dateStr] {
+			return false
+		}
+	}
+
+	// Per-condition exclude period check
+	if len(cond.excludePeriods) > 0 {
+		month := int(localTime.Month())
+		day := localTime.Day()
+		for i := range cond.excludePeriods {
+			if periodMatches(&cond.excludePeriods[i], month, day) {
+				return false
+			}
+		}
+	}
+
+	// Per-condition exclude date check
+	if len(cond.excludeDates) > 0 {
+		dateStr := localTime.Format("2006-01-02")
+		if cond.excludeDates[dateStr] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// TimeWindow represents a half-open time interval [From, To) where the schedule
+// is active. Times are in the schedule's timezone.
+type TimeWindow struct {
+	From time.Time
+	To   time.Time
+}
+
+// ActiveWindows returns a stream of sorted, non-overlapping time intervals within
+// [from, to) where the schedule is active. Resolution is one minute, matching the
+// schedule's time-slot granularity. Times in the returned windows are in the
+// schedule's timezone. The stream is lazy — non-matching days are skipped in O(1)
+// and iteration stops as soon as the consumer stops pulling.
+func (s Schedule) ActiveWindows(from, to time.Time) stream.Stream[TimeWindow] {
+	return stream.FromIterator(s.activeWindowsIter(from, to))
+}
+
+// MatchesPeriod reports whether any moment within [from, to) matches the schedule.
+// Efficient: stops at the first matching minute without scanning the entire range.
+func (s Schedule) MatchesPeriod(from, to time.Time) bool {
+	empty, _ := s.ActiveWindows(from, to).IsEmpty(context.Background())
+	return !empty
+}
+
+// activeWindowsIter returns a Go iterator that yields active time windows.
+func (s Schedule) activeWindowsIter(from, to time.Time) iter.Seq[TimeWindow] {
+	return func(yield func(TimeWindow) bool) {
+		if !from.Before(to) {
+			return
+		}
+
+		localFrom := from.In(s.location)
+		localTo := to.In(s.location)
+		dayStart := time.Date(localFrom.Year(), localFrom.Month(), localFrom.Day(), 0, 0, 0, 0, s.location)
+
+		// Merge-adjacent buffer: hold one window to check if the next is contiguous.
+		var pending *TimeWindow
+
+		emit := func(w TimeWindow) bool {
+			if pending == nil {
+				pending = &w
+				return true
+			}
+			if !w.From.After(pending.To) {
+				// Adjacent or overlapping — extend.
+				if w.To.After(pending.To) {
+					pending.To = w.To
+				}
+				return true
+			}
+			// Gap — yield the pending window, buffer the new one.
+			result := *pending
+			pending = &w
+			return yield(result)
+		}
+
+		for ; dayStart.Before(localTo); dayStart = dayStart.AddDate(0, 0, 1) {
+			if !s.MatchesDay(dayStart) {
+				continue
+			}
+
+			scanFrom := dayStart
+			if localFrom.After(scanFrom) {
+				scanFrom = time.Date(localFrom.Year(), localFrom.Month(), localFrom.Day(), localFrom.Hour(), localFrom.Minute(), 0, 0, s.location)
+			}
+			scanTo := dayStart.AddDate(0, 0, 1)
+			if localTo.Before(scanTo) {
+				scanTo = localTo
+			}
+
+			var windowStart *time.Time
+			for t := scanFrom; t.Before(scanTo); t = t.Add(time.Minute) {
+				if s.Matches(t) {
+					if windowStart == nil {
+						start := t
+						windowStart = &start
+					}
+				} else if windowStart != nil {
+					if !emit(TimeWindow{From: *windowStart, To: t}) {
+						return
+					}
+					windowStart = nil
+				}
+			}
+			if windowStart != nil {
+				if !emit(TimeWindow{From: *windowStart, To: scanTo}) {
+					return
+				}
+				windowStart = nil
+			}
+		}
+
+		// Flush the last pending window.
+		if pending != nil {
+			yield(*pending)
+		}
+	}
 }
 
 // timeSlotMatches checks if the current minute-of-day falls within the time slot.

--- a/utils/timeseries/tsquery/datasource/schedule_test.go
+++ b/utils/timeseries/tsquery/datasource/schedule_test.go
@@ -867,6 +867,1151 @@ func TestSchedule_ExcludeDates_InvalidFormat(t *testing.T) {
 	require.Contains(t, err.Error(), "invalid excludeDate format")
 }
 
+// =============================================================================
+// MatchesDay Tests
+// =============================================================================
+
+// --- MatchesDay: Basic ---
+
+func TestMatchesDay_BasicMatch_IgnoresTimeSlots(t *testing.T) {
+	// Schedule with time-slot 09:00-17:00 and weekday constraint
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5}, // Mon–Fri
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Monday June 17, 2024 — weekday matches. MatchesDay ignores time-slots.
+	date := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+	require.Equal(t, time.Monday, date.Weekday())
+	require.True(t, s.MatchesDay(date))
+}
+
+func TestMatchesDay_WeekendNoMatch(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Saturday June 15, 2024 — weekday fails.
+	date := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	require.Equal(t, time.Saturday, date.Weekday())
+	require.False(t, s.MatchesDay(date))
+}
+
+func TestMatchesDay_TimeComponentIgnored(t *testing.T) {
+	// Time-slot only: 09:00-17:00. MatchesDay should ignore it entirely.
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Pass 03:00 — outside the time-slot, but MatchesDay should still return true.
+	date := time.Date(2024, 6, 15, 3, 0, 0, 0, time.UTC)
+	require.True(t, s.MatchesDay(date))
+
+	// Pass 23:59 — also outside. Still true.
+	date2 := time.Date(2024, 6, 15, 23, 59, 0, 0, time.UTC)
+	require.True(t, s.MatchesDay(date2))
+}
+
+func TestMatchesDay_NoConditions_NoMatch(t *testing.T) {
+	s := NewSchedule(nil, nil, nil, nil, time.UTC)
+	require.False(t, s.MatchesDay(time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_EmptyCondition_MatchesAnyDay(t *testing.T) {
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	require.True(t, s.MatchesDay(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)))
+	require.True(t, s.MatchesDay(time.Date(2024, 7, 4, 0, 0, 0, 0, time.UTC)))
+	require.True(t, s.MatchesDay(time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)))
+}
+
+// --- MatchesDay: Period ---
+
+func TestMatchesDay_Period_WithinPeriod(t *testing.T) {
+	cond, err := NewScheduleCondition(nil, nil,
+		[]SchedulePeriod{mustPeriod(t, 6, 1, 8, 31)}, // Jun–Aug (summer)
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	require.True(t, s.MatchesDay(time.Date(2024, 7, 15, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_Period_OutsidePeriod(t *testing.T) {
+	cond, err := NewScheduleCondition(nil, nil,
+		[]SchedulePeriod{mustPeriod(t, 6, 1, 8, 31)},
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	require.False(t, s.MatchesDay(time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_Period_CrossYear(t *testing.T) {
+	// Winter: Nov 1 – Feb 28
+	cond, err := NewScheduleCondition(nil, nil,
+		[]SchedulePeriod{mustPeriod(t, 11, 1, 2, 28)},
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	require.True(t, s.MatchesDay(time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC)))
+	require.True(t, s.MatchesDay(time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)))
+	require.False(t, s.MatchesDay(time.Date(2024, 5, 15, 0, 0, 0, 0, time.UTC)))
+}
+
+// --- MatchesDay: Specific Dates ---
+
+func TestMatchesDay_SpecificDate_Match(t *testing.T) {
+	cond, err := NewScheduleCondition(nil, nil, nil, []string{"2024-12-25"}, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	require.True(t, s.MatchesDay(time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC)))
+	require.False(t, s.MatchesDay(time.Date(2024, 12, 26, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_SpecificDate_WithTimeSlot_StillMatchesDay(t *testing.T) {
+	// Has time-slot 09:00-12:00 AND specific date. MatchesDay ignores time-slot.
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 12, 0)},
+		nil, nil, []string{"2024-12-25"}, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	require.True(t, s.MatchesDay(time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC)))
+}
+
+// --- MatchesDay: Bounds (day-level) ---
+
+func TestMatchesDay_Bounds_BeforeStartTime(t *testing.T) {
+	start := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC) // starts mid-day
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, &start, nil, time.UTC)
+
+	// June 14 — entirely before startTime → no match
+	require.False(t, s.MatchesDay(time.Date(2024, 6, 14, 0, 0, 0, 0, time.UTC)))
+
+	// June 15 — overlaps startTime (start is at 10:00, day goes to 24:00) → match
+	require.True(t, s.MatchesDay(time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)))
+
+	// June 16 — fully after startTime → match
+	require.True(t, s.MatchesDay(time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_Bounds_AfterEndTime(t *testing.T) {
+	end := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC) // ends mid-day
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, &end, time.UTC)
+
+	// June 30 — fully before endTime → match
+	require.True(t, s.MatchesDay(time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)))
+
+	// July 1 — partially before endTime (00:00-12:00) → match
+	require.True(t, s.MatchesDay(time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)))
+
+	// July 2 — entirely after endTime → no match
+	require.False(t, s.MatchesDay(time.Date(2024, 7, 2, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_Bounds_EndTimeAtMidnight(t *testing.T) {
+	// End at midnight of July 1 means June 30 is the last full day.
+	end := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, &end, time.UTC)
+
+	require.True(t, s.MatchesDay(time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)))
+	// July 1 at midnight: dayStart=July 1 00:00, endTime=July 1 00:00. dayStart.Before(endTime) is false.
+	require.False(t, s.MatchesDay(time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_Bounds_BothBounds(t *testing.T) {
+	start := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, &start, &end, time.UTC)
+
+	require.False(t, s.MatchesDay(time.Date(2024, 5, 31, 0, 0, 0, 0, time.UTC)))
+	require.True(t, s.MatchesDay(time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)))
+	require.True(t, s.MatchesDay(time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)))
+	require.False(t, s.MatchesDay(time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)))
+}
+
+// --- MatchesDay: Exclude Conditions ---
+
+func TestMatchesDay_Exclude_HolidayExcluded(t *testing.T) {
+	// Business: weekdays
+	cond, err := NewScheduleCondition(nil, []int{1, 2, 3, 4, 5}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	// Exclude Christmas
+	excludeCond, err := NewScheduleCondition(nil, nil, nil, []string{"2024-12-25"}, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, []ScheduleCondition{excludeCond}, nil, nil, time.UTC)
+
+	// Wednesday Dec 25 → weekday, but excluded
+	require.False(t, s.MatchesDay(time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC)))
+
+	// Thursday Dec 26 → weekday, not excluded
+	require.True(t, s.MatchesDay(time.Date(2024, 12, 26, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_Exclude_WeekendExcluded(t *testing.T) {
+	// Include: all days
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	// Exclude: weekends
+	excludeCond, err := NewScheduleCondition(nil, []int{0, 6}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, []ScheduleCondition{excludeCond}, nil, nil, time.UTC)
+
+	require.True(t, s.MatchesDay(time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)))  // Monday
+	require.False(t, s.MatchesDay(time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC))) // Saturday
+	require.False(t, s.MatchesDay(time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC))) // Sunday
+}
+
+func TestMatchesDay_PerConditionExcludePeriod(t *testing.T) {
+	// Weekdays, but exclude all of December
+	cond, err := NewScheduleCondition(
+		nil,
+		[]int{1, 2, 3, 4, 5},
+		nil, nil,
+		[]SchedulePeriod{mustPeriod(t, 12, 1, 12, 31)},
+		nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Monday in November → match
+	require.True(t, s.MatchesDay(time.Date(2024, 11, 18, 0, 0, 0, 0, time.UTC)))
+
+	// Monday in December → excluded by per-condition period
+	require.False(t, s.MatchesDay(time.Date(2024, 12, 16, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_PerConditionExcludeDate(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		nil, nil, nil, nil,
+		nil, []string{"2024-07-04"},
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	require.False(t, s.MatchesDay(time.Date(2024, 7, 4, 0, 0, 0, 0, time.UTC)))
+	require.True(t, s.MatchesDay(time.Date(2024, 7, 3, 0, 0, 0, 0, time.UTC)))
+	// Same date next year → not excluded (dates are specific)
+	require.True(t, s.MatchesDay(time.Date(2025, 7, 4, 0, 0, 0, 0, time.UTC)))
+}
+
+// --- MatchesDay: OR between conditions ---
+
+func TestMatchesDay_OR_MultipleConditions(t *testing.T) {
+	// Condition 1: weekdays in summer
+	cond1, err := NewScheduleCondition(nil, []int{1, 2, 3, 4, 5},
+		[]SchedulePeriod{mustPeriod(t, 6, 1, 8, 31)},
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	// Condition 2: specific holidays (any day of week)
+	cond2, err := NewScheduleCondition(nil, nil, nil,
+		[]string{"2024-12-25", "2025-01-01"},
+		nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond1, cond2}, nil, nil, nil, time.UTC)
+
+	// Summer weekday → cond1 matches
+	require.True(t, s.MatchesDay(time.Date(2024, 7, 15, 0, 0, 0, 0, time.UTC)))
+	// Summer weekend → cond1 fails (weekday), cond2 fails (not a holiday)
+	require.False(t, s.MatchesDay(time.Date(2024, 7, 13, 0, 0, 0, 0, time.UTC)))
+	// Christmas → cond1 fails (not summer), cond2 matches
+	require.True(t, s.MatchesDay(time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC)))
+	// Random winter weekday → neither
+	require.False(t, s.MatchesDay(time.Date(2024, 11, 18, 0, 0, 0, 0, time.UTC)))
+}
+
+// --- MatchesDay: Timezone ---
+
+func TestMatchesDay_Timezone_UTCPlus_DayShift(t *testing.T) {
+	// Schedule in UTC+9 (Tokyo). Weekdays only.
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
+	cond, err := NewScheduleCondition(nil, []int{1, 2, 3, 4, 5}, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, tokyo)
+
+	// Friday June 14 2024 at 20:00 UTC = Saturday June 15 05:00 Tokyo
+	// → In Tokyo it's Saturday → weekday check fails
+	date := time.Date(2024, 6, 14, 20, 0, 0, 0, time.UTC)
+	require.Equal(t, time.Friday, date.Weekday()) // UTC is Friday
+	require.False(t, s.MatchesDay(date))           // Tokyo is Saturday → false
+
+	// Friday June 14 2024 at 14:00 UTC = Friday June 14 23:00 Tokyo
+	// → In Tokyo it's still Friday → weekday check passes
+	date2 := time.Date(2024, 6, 14, 14, 0, 0, 0, time.UTC)
+	require.True(t, s.MatchesDay(date2))
+}
+
+func TestMatchesDay_Timezone_UTCMinus_DayShift(t *testing.T) {
+	// Schedule in US Eastern (UTC-5 / UTC-4 DST).
+	eastern, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	// Date: 2024-12-25 only
+	cond, err := NewScheduleCondition(nil, nil, nil, []string{"2024-12-25"}, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, eastern)
+
+	// Dec 25 01:00 UTC = Dec 24 20:00 Eastern → in Eastern it's Dec 24 → no match
+	require.False(t, s.MatchesDay(time.Date(2024, 12, 25, 1, 0, 0, 0, time.UTC)))
+
+	// Dec 25 06:00 UTC = Dec 25 01:00 Eastern → in Eastern it's Dec 25 → match
+	require.True(t, s.MatchesDay(time.Date(2024, 12, 25, 6, 0, 0, 0, time.UTC)))
+
+	// Dec 26 04:00 UTC = Dec 25 23:00 Eastern → still Dec 25 → match
+	require.True(t, s.MatchesDay(time.Date(2024, 12, 26, 4, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_Timezone_BoundsInDifferentTZ(t *testing.T) {
+	// Schedule in UTC+3 (Israel). Start: July 1 00:00 UTC+3 = June 30 21:00 UTC
+	israel := time.FixedZone("IST", 3*60*60)
+	start := time.Date(2024, 7, 1, 0, 0, 0, 0, israel) // = June 30 21:00 UTC
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, &start, nil, israel)
+
+	// June 30 in Israel → entirely before start (July 1 00:00 Israel)
+	require.False(t, s.MatchesDay(time.Date(2024, 6, 30, 12, 0, 0, 0, israel)))
+
+	// July 1 in Israel → starts at the boundary → match
+	require.True(t, s.MatchesDay(time.Date(2024, 7, 1, 0, 0, 0, 0, israel)))
+}
+
+// --- MatchesDay: Complex / realistic scenarios ---
+
+func TestMatchesDay_EnergyPeakDay_Realistic(t *testing.T) {
+	// Peak schedule: weekdays, summer period (Jun–Sep), exclude July 4
+	peakCond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 14, 0, 18, 0)}, // 2–6 PM peak hours
+		[]int{1, 2, 3, 4, 5},                               // weekdays
+		[]SchedulePeriod{mustPeriod(t, 6, 1, 9, 30)},       // summer
+		nil,
+		nil, []string{"2024-07-04"}, // exclude Independence Day
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{peakCond}, nil, nil, nil, time.UTC)
+
+	// Peak day: Wednesday July 10 → weekday + summer + not July 4
+	require.True(t, s.MatchesDay(time.Date(2024, 7, 10, 0, 0, 0, 0, time.UTC)))
+
+	// July 4 → excluded
+	require.False(t, s.MatchesDay(time.Date(2024, 7, 4, 0, 0, 0, 0, time.UTC)))
+
+	// Saturday July 13 → weekend → false
+	require.False(t, s.MatchesDay(time.Date(2024, 7, 13, 0, 0, 0, 0, time.UTC)))
+
+	// Monday Nov 4 → outside summer → false
+	require.False(t, s.MatchesDay(time.Date(2024, 11, 4, 0, 0, 0, 0, time.UTC)))
+
+	// The time-slot (14-18) is ignored by MatchesDay — the day is still a "peak day"
+	// even though only 4 hours are actually peak
+	require.True(t, s.MatchesDay(time.Date(2024, 8, 5, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestMatchesDay_ConsistentWithMatches(t *testing.T) {
+	// If MatchesDay is true, at least one minute on that day should Matches()==true.
+	// (Because a matching day-level condition must have at least some active time-slot.)
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Monday June 17 — MatchesDay should be true
+	date := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+	require.True(t, s.MatchesDay(date))
+
+	// Verify at least one minute matches
+	found := false
+	for h := 0; h < 24 && !found; h++ {
+		for m := 0; m < 60 && !found; m++ {
+			if s.Matches(time.Date(2024, 6, 17, h, m, 0, 0, time.UTC)) {
+				found = true
+			}
+		}
+	}
+	require.True(t, found, "MatchesDay==true but no minute on that day Matches()==true")
+
+	// Saturday June 15 — MatchesDay should be false
+	date2 := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	require.False(t, s.MatchesDay(date2))
+}
+
+// =============================================================================
+// ActiveWindows Tests
+// =============================================================================
+
+// --- ActiveWindows: Basic ---
+
+func TestActiveWindows_SingleSlot_FullDay(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 1)
+	require.Equal(t, time.Date(2024, 6, 15, 9, 0, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 15, 17, 0, 0, 0, time.UTC), windows[0].To)
+}
+
+func TestActiveWindows_NoConditions_Empty(t *testing.T) {
+	s := NewSchedule(nil, nil, nil, nil, time.UTC)
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	require.Empty(t, s.ActiveWindows(from, to).MustCollect())
+}
+
+func TestActiveWindows_EmptyCondition_AllDay(t *testing.T) {
+	// No time-slot constraint → every minute matches
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 1)
+	require.Equal(t, from, windows[0].From)
+	require.Equal(t, to, windows[0].To)
+}
+
+func TestActiveWindows_InvalidRange_Empty(t *testing.T) {
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// to before from
+	to := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	from := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	require.Empty(t, s.ActiveWindows(from, to).MustCollect())
+
+	// equal
+	require.Empty(t, s.ActiveWindows(from, from).MustCollect())
+}
+
+// --- ActiveWindows: Multiple Slots ---
+
+func TestActiveWindows_MultipleSlots_SameDay(t *testing.T) {
+	// Morning + afternoon blocks
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{
+			mustTimeSlot(t, 9, 0, 12, 0),
+			mustTimeSlot(t, 13, 0, 17, 0),
+		},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 2)
+	require.Equal(t, time.Date(2024, 6, 15, 9, 0, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC), windows[0].To)
+	require.Equal(t, time.Date(2024, 6, 15, 13, 0, 0, 0, time.UTC), windows[1].From)
+	require.Equal(t, time.Date(2024, 6, 15, 17, 0, 0, 0, time.UTC), windows[1].To)
+}
+
+// --- ActiveWindows: Cross-midnight ---
+
+func TestActiveWindows_CrossMidnight_SingleDay(t *testing.T) {
+	// 22:00–06:00 cross-midnight slot
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 22, 0, 6, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Query a full day — should get two pieces: 00:00–06:00 and 22:00–00:00
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 2)
+	require.Equal(t, time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 15, 6, 0, 0, 0, time.UTC), windows[0].To)
+	require.Equal(t, time.Date(2024, 6, 15, 22, 0, 0, 0, time.UTC), windows[1].From)
+	require.Equal(t, time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC), windows[1].To)
+}
+
+func TestActiveWindows_CrossMidnight_TwoDays_Merges(t *testing.T) {
+	// 22:00–06:00, query two days → should merge across midnight
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 22, 0, 6, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// Day 15: 00:00–06:00, 22:00–00:00
+	// Day 16: 00:00–06:00, 22:00–00:00
+	// After merge: 00:00–06:00, 22:00–06:00 (merged across midnight), 22:00–00:00
+	require.Len(t, windows, 3)
+	require.Equal(t, time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 15, 6, 0, 0, 0, time.UTC), windows[0].To)
+	require.Equal(t, time.Date(2024, 6, 15, 22, 0, 0, 0, time.UTC), windows[1].From)
+	require.Equal(t, time.Date(2024, 6, 16, 6, 0, 0, 0, time.UTC), windows[1].To)
+	require.Equal(t, time.Date(2024, 6, 16, 22, 0, 0, 0, time.UTC), windows[2].From)
+	require.Equal(t, time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC), windows[2].To)
+}
+
+// --- ActiveWindows: Multiple Days ---
+
+func TestActiveWindows_MultipleDays_BusinessHours(t *testing.T) {
+	// Weekdays 09:00-17:00
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Monday June 17 through Sunday June 23 (full week)
+	from := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC) // Monday
+	to := time.Date(2024, 6, 24, 0, 0, 0, 0, time.UTC)   // Next Monday
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// 5 weekdays × 1 window each
+	require.Len(t, windows, 5)
+	for i, w := range windows {
+		expectedDay := 17 + i
+		require.Equal(t, time.Date(2024, 6, expectedDay, 9, 0, 0, 0, time.UTC), w.From,
+			"window %d From", i)
+		require.Equal(t, time.Date(2024, 6, expectedDay, 17, 0, 0, 0, time.UTC), w.To,
+			"window %d To", i)
+	}
+}
+
+func TestActiveWindows_SkipsNonMatchingDays(t *testing.T) {
+	// Only Mondays
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 10, 0, 11, 0)},
+		[]int{1}, // Monday only
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Two weeks
+	from := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC) // Monday
+	to := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)    // Monday
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 2) // June 17, June 24
+	require.Equal(t, 17, windows[0].From.Day())
+	require.Equal(t, 24, windows[1].From.Day())
+}
+
+// --- ActiveWindows: Exclude Conditions ---
+
+func TestActiveWindows_Exclude_LunchHour(t *testing.T) {
+	// Include: 09:00-17:00
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	// Exclude: 12:00-13:00 (lunch)
+	excludeCond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 12, 0, 13, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, []ScheduleCondition{excludeCond}, nil, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 2)
+	require.Equal(t, time.Date(2024, 6, 15, 9, 0, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC), windows[0].To)
+	require.Equal(t, time.Date(2024, 6, 15, 13, 0, 0, 0, time.UTC), windows[1].From)
+	require.Equal(t, time.Date(2024, 6, 15, 17, 0, 0, 0, time.UTC), windows[1].To)
+}
+
+func TestActiveWindows_Exclude_EntireDay(t *testing.T) {
+	// Include: all days, 09:00-17:00
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	// Exclude: specific date
+	excludeCond, err := NewScheduleCondition(nil, nil, nil, []string{"2024-06-16"}, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, []ScheduleCondition{excludeCond}, nil, nil, time.UTC)
+
+	// Three days: June 15-17
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 18, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// June 16 is fully excluded → only June 15 and 17
+	require.Len(t, windows, 2)
+	require.Equal(t, 15, windows[0].From.Day())
+	require.Equal(t, 17, windows[1].From.Day())
+}
+
+// --- ActiveWindows: Bounds ---
+
+func TestActiveWindows_Bounds_ClippedByStartTime(t *testing.T) {
+	start := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, &start, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// Should start at 10:30 (clipped by startTime), end at 17:00
+	require.Len(t, windows, 1)
+	require.Equal(t, time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 15, 17, 0, 0, 0, time.UTC), windows[0].To)
+}
+
+func TestActiveWindows_Bounds_ClippedByEndTime(t *testing.T) {
+	end := time.Date(2024, 6, 15, 14, 0, 0, 0, time.UTC)
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, &end, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// Should start at 09:00, end at 14:00 (clipped by endTime)
+	require.Len(t, windows, 1)
+	require.Equal(t, time.Date(2024, 6, 15, 9, 0, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 15, 14, 0, 0, 0, time.UTC), windows[0].To)
+}
+
+func TestActiveWindows_Bounds_EntirelyOutside(t *testing.T) {
+	start := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC)
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, &start, &end, time.UTC)
+
+	// Query June — entirely before schedule bounds
+	from := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	require.Empty(t, s.ActiveWindows(from, to).MustCollect())
+}
+
+// --- ActiveWindows: Partial day query ---
+
+func TestActiveWindows_PartialDay_Afternoon(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Query 14:00-16:00 only
+	from := time.Date(2024, 6, 15, 14, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 15, 16, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 1)
+	require.Equal(t, from, windows[0].From)
+	require.Equal(t, to, windows[0].To)
+}
+
+func TestActiveWindows_PartialDay_SpansBoundary(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Query 15:00-20:00 — partially inside slot
+	from := time.Date(2024, 6, 15, 15, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 15, 20, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 1)
+	require.Equal(t, time.Date(2024, 6, 15, 15, 0, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 15, 17, 0, 0, 0, time.UTC), windows[0].To)
+}
+
+// --- ActiveWindows: Timezone ---
+
+func TestActiveWindows_Timezone_NonUTC(t *testing.T) {
+	// Schedule in UTC+3. Business hours 09:00-17:00 local.
+	loc := time.FixedZone("UTC+3", 3*60*60)
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, loc)
+
+	// Query in UTC: full day June 15
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// 09:00–17:00 UTC+3 = 06:00–14:00 UTC
+	// But windows are returned in schedule tz (UTC+3).
+	// The query range in UTC+3 is 03:00–03:00(+1).
+	// Active: 09:00–17:00 in UTC+3, clipped to 03:00–03:00 → 09:00–17:00
+	require.Len(t, windows, 1)
+	require.Equal(t, 9, windows[0].From.Hour())
+	require.Equal(t, 17, windows[0].To.Hour())
+}
+
+func TestActiveWindows_Timezone_Tokyo_Weekday(t *testing.T) {
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
+	// Weekdays 09:00-17:00 Tokyo time
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, tokyo)
+
+	// Query: Friday June 14 2024 in Tokyo time
+	from := time.Date(2024, 6, 14, 0, 0, 0, 0, tokyo)
+	to := time.Date(2024, 6, 15, 0, 0, 0, 0, tokyo) // Saturday
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 1)
+	require.Equal(t, time.Date(2024, 6, 14, 9, 0, 0, 0, tokyo), windows[0].From)
+	require.Equal(t, time.Date(2024, 6, 14, 17, 0, 0, 0, tokyo), windows[0].To)
+
+	// Query Saturday — no windows
+	from2 := time.Date(2024, 6, 15, 0, 0, 0, 0, tokyo)
+	to2 := time.Date(2024, 6, 16, 0, 0, 0, 0, tokyo)
+	require.Empty(t, s.ActiveWindows(from2, to2).MustCollect())
+}
+
+func TestActiveWindows_Timezone_DST_SpringForward(t *testing.T) {
+	// US Eastern: spring forward on March 10, 2024 at 02:00
+	eastern, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 1, 0, 4, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, eastern)
+
+	// Query the DST transition day
+	from := time.Date(2024, 3, 10, 0, 0, 0, 0, eastern)
+	to := time.Date(2024, 3, 11, 0, 0, 0, 0, eastern)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// 01:00-02:00 exists, 02:00-03:00 is skipped (spring forward), 03:00-04:00 exists
+	// The schedule should still produce a window, though its duration may be shorter
+	require.NotEmpty(t, windows)
+	require.Equal(t, 1, windows[0].From.Hour())
+}
+
+// --- ActiveWindows: Per-condition excludes ---
+
+func TestActiveWindows_PerConditionExclude_HolidayReducedHours(t *testing.T) {
+	// Condition 1: Weekdays full hours, exclude Christmas
+	weekdayCond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil,
+		nil, []string{"2024-12-25"},
+	)
+	require.NoError(t, err)
+	// Condition 2: Christmas reduced hours
+	holidayCond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 10, 0, 14, 0)},
+		nil, nil,
+		[]string{"2024-12-25"},
+		nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{weekdayCond, holidayCond}, nil, nil, nil, time.UTC)
+
+	// Dec 25 (Wednesday) — weekday condition excluded, holiday condition applies
+	from := time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 12, 26, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 1)
+	require.Equal(t, time.Date(2024, 12, 25, 10, 0, 0, 0, time.UTC), windows[0].From)
+	require.Equal(t, time.Date(2024, 12, 25, 14, 0, 0, 0, time.UTC), windows[0].To)
+
+	// Dec 26 (Thursday) — normal weekday hours
+	from2 := time.Date(2024, 12, 26, 0, 0, 0, 0, time.UTC)
+	to2 := time.Date(2024, 12, 27, 0, 0, 0, 0, time.UTC)
+	windows2 := s.ActiveWindows(from2, to2).MustCollect()
+
+	require.Len(t, windows2, 1)
+	require.Equal(t, time.Date(2024, 12, 26, 9, 0, 0, 0, time.UTC), windows2[0].From)
+	require.Equal(t, time.Date(2024, 12, 26, 17, 0, 0, 0, time.UTC), windows2[0].To)
+}
+
+// --- ActiveWindows: Complex / realistic ---
+
+func TestActiveWindows_EnergyPeakSchedule(t *testing.T) {
+	// Peak: weekdays 14:00-18:00, summer only, exclude July 4
+	peakCond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 14, 0, 18, 0)},
+		[]int{1, 2, 3, 4, 5},
+		[]SchedulePeriod{mustPeriod(t, 6, 1, 9, 30)},
+		nil,
+		nil, []string{"2024-07-04"},
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{peakCond}, nil, nil, nil, time.UTC)
+
+	// Week of July 1-7, 2024: Mon(1), Tue(2), Wed(3), Thu(4=excl), Fri(5), Sat(6), Sun(7)
+	from := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 7, 8, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// 4 weekdays (July 4 excluded, weekend excluded)
+	require.Len(t, windows, 4)
+
+	days := make([]int, len(windows))
+	for i, w := range windows {
+		days[i] = w.From.Day()
+		require.Equal(t, 14, w.From.Hour())
+		require.Equal(t, 18, w.To.Hour())
+	}
+	require.Equal(t, []int{1, 2, 3, 5}, days)
+}
+
+func TestActiveWindows_MultiWeek_OnlyMatchingDays(t *testing.T) {
+	// Wednesday-only schedule, 08:00-12:00
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 8, 0, 12, 0)},
+		[]int{3}, // Wednesday
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// June 2024: Wednesdays are 5, 12, 19, 26
+	from := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 4)
+	for i, w := range windows {
+		require.Equal(t, time.Wednesday, w.From.Weekday(), "window %d", i)
+		require.Equal(t, 8, w.From.Hour())
+		require.Equal(t, 12, w.To.Hour())
+	}
+}
+
+// --- ActiveWindows: len() == 0 as MatchesBetween ---
+
+func TestActiveWindows_AsMatchesBetween(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Weekday range — has windows
+	from := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC) // Monday
+	to := time.Date(2024, 6, 18, 0, 0, 0, 0, time.UTC)
+	require.True(t, len(s.ActiveWindows(from, to).MustCollect()) > 0)
+
+	// Weekend range — no windows
+	from2 := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC) // Saturday
+	to2 := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	require.True(t, len(s.ActiveWindows(from2, to2).MustCollect()) == 0)
+}
+
+// --- ActiveWindows: OR conditions union ---
+
+func TestActiveWindows_ORConditions_Union(t *testing.T) {
+	// Condition 1: morning 09:00-12:00
+	cond1, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 12, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	// Condition 2: afternoon 14:00-17:00
+	cond2, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 14, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond1, cond2}, nil, nil, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	require.Len(t, windows, 2)
+	require.Equal(t, 9, windows[0].From.Hour())
+	require.Equal(t, 12, windows[0].To.Hour())
+	require.Equal(t, 14, windows[1].From.Hour())
+	require.Equal(t, 17, windows[1].To.Hour())
+}
+
+func TestActiveWindows_ORConditions_Overlapping_Merged(t *testing.T) {
+	// Condition 1: 09:00-14:00
+	cond1, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 14, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	// Condition 2: 12:00-17:00 (overlaps)
+	cond2, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 12, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond1, cond2}, nil, nil, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	// Overlapping → merged into single 09:00-17:00
+	require.Len(t, windows, 1)
+	require.Equal(t, 9, windows[0].From.Hour())
+	require.Equal(t, 17, windows[0].To.Hour())
+}
+
+// --- ActiveWindows: Duration calculation use-case ---
+
+func TestActiveWindows_TotalDuration(t *testing.T) {
+	// Business hours with lunch break excluded
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	excludeCond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 12, 0, 13, 0)},
+		nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, []ScheduleCondition{excludeCond}, nil, nil, time.UTC)
+
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	windows := s.ActiveWindows(from, to).MustCollect()
+
+	var totalMinutes int
+	for _, w := range windows {
+		totalMinutes += int(w.To.Sub(w.From).Minutes())
+	}
+	// 3h morning (09-12) + 4h afternoon (13-17) = 7h = 420 min
+	require.Equal(t, 420, totalMinutes)
+}
+
+// =============================================================================
+// MatchesPeriod Tests
+// =============================================================================
+
+func TestMatchesPeriod_BasicMatch(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Monday — has active time
+	from := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 18, 0, 0, 0, 0, time.UTC)
+	require.True(t, s.MatchesPeriod(from, to))
+}
+
+func TestMatchesPeriod_NoMatch(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Saturday — no active time
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC)
+	require.False(t, s.MatchesPeriod(from, to))
+}
+
+func TestMatchesPeriod_WeekRange_HasWeekday(t *testing.T) {
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// Full week — contains weekdays → true
+	from := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC) // Saturday
+	to := time.Date(2024, 6, 22, 0, 0, 0, 0, time.UTC)
+	require.True(t, s.MatchesPeriod(from, to))
+}
+
+func TestMatchesPeriod_MonthRange(t *testing.T) {
+	// Summer only: Jun–Aug
+	cond, err := NewScheduleCondition(nil, nil,
+		[]SchedulePeriod{mustPeriod(t, 6, 1, 8, 31)},
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// July — within summer
+	require.True(t, s.MatchesPeriod(
+		time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 8, 1, 0, 0, 0, 0, time.UTC),
+	))
+
+	// February — outside summer
+	require.False(t, s.MatchesPeriod(
+		time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC),
+	))
+}
+
+func TestMatchesPeriod_EmptyRange(t *testing.T) {
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	ts := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+	require.False(t, s.MatchesPeriod(ts, ts)) // equal
+}
+
+func TestMatchesPeriod_NoConditions(t *testing.T) {
+	s := NewSchedule(nil, nil, nil, nil, time.UTC)
+	require.False(t, s.MatchesPeriod(
+		time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 6, 16, 0, 0, 0, 0, time.UTC),
+	))
+}
+
+func TestMatchesPeriod_Timezone_NonUTC(t *testing.T) {
+	// Schedule in UTC+9 (Tokyo). Weekdays only.
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, tokyo)
+
+	// Friday in Tokyo time — should match
+	require.True(t, s.MatchesPeriod(
+		time.Date(2024, 6, 14, 0, 0, 0, 0, tokyo),
+		time.Date(2024, 6, 15, 0, 0, 0, 0, tokyo),
+	))
+
+	// Saturday in Tokyo time — should not match
+	require.False(t, s.MatchesPeriod(
+		time.Date(2024, 6, 15, 0, 0, 0, 0, tokyo),
+		time.Date(2024, 6, 16, 0, 0, 0, 0, tokyo),
+	))
+}
+
+func TestMatchesPeriod_WithExcludes(t *testing.T) {
+	// Weekdays, but exclude Christmas
+	cond, err := NewScheduleCondition(
+		[]ScheduleTimeSlot{mustTimeSlot(t, 9, 0, 17, 0)},
+		[]int{1, 2, 3, 4, 5},
+		nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+	excludeCond, err := NewScheduleCondition(nil, nil, nil, []string{"2024-12-25"}, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, []ScheduleCondition{excludeCond}, nil, nil, time.UTC)
+
+	// Christmas day only (Wednesday) — excluded
+	require.False(t, s.MatchesPeriod(
+		time.Date(2024, 12, 25, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 12, 26, 0, 0, 0, 0, time.UTC),
+	))
+
+	// Christmas week — other weekdays still match
+	require.True(t, s.MatchesPeriod(
+		time.Date(2024, 12, 23, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC),
+	))
+}
+
+func TestMatchesPeriod_Efficient_StopsEarly(t *testing.T) {
+	// Large range but first day matches — should return quickly
+	cond, err := NewScheduleCondition(nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	s := NewSchedule([]ScheduleCondition{cond}, nil, nil, nil, time.UTC)
+
+	// One year range — but should return true almost instantly
+	require.True(t, s.MatchesPeriod(
+		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	))
+}
+
 // --- Test Helpers ---
 
 func mustTimeSlot(t *testing.T, fromHour, fromMinute, toHour, toMinute int) ScheduleTimeSlot {


### PR DESCRIPTION
Add day-level and range-level schedule query helpers:

- MatchesDay(date) bool: checks whether a calendar date falls within the schedule, ignoring time-slot constraints. Uses day-level bounds overlap and skips time-slot-only exclude conditions (they reduce hours, not eliminate days). Enables direct use as isPeakDay method ref.

- ActiveWindows(from, to) stream.Stream[TimeWindow]: returns a lazy stream of sorted, non-overlapping time intervals where the schedule is active. Uses iter.Seq internally via stream.FromIterator. MatchesDay serves as O(1) fast-skip for non-matching days; matching days are scanned minute-by-minute via existing Matches(). Adjacent windows across day boundaries are merged (cross-midnight slots).

- MatchesPeriod(from, to) bool: reports whether any moment in the range matches. Implemented as !ActiveWindows(from,to).IsEmpty() — efficient early termination on first match.

- TimeWindow struct with From/To time.Time (half-open [From, To)).

Existing Matches() and conditionMatches() are completely untouched.