### PR TITLE
Add numeric auto-promotion (integer → decimal) for mixed-type express…

### DIFF
--- a/utils/timeseries/tsquery/aggregation/aggregation_value.go
+++ b/utils/timeseries/tsquery/aggregation/aggregation_value.go
@@ -87,21 +87,43 @@ func (n *NumericExpressionAggregationValue) Evaluate(resolved map[string]Resolve
 		return nil, "", fmt.Errorf("failed to evaluate op2: %w", err)
 	}
 
-	// Nil propagation: if either operand is nil, result is nil
-	if v1 == nil || v2 == nil {
-		return nil, dt1, nil
-	}
-
+	// Auto-promote numeric types (int → decimal) — compute promoted type before nil check
+	// so that nil propagation returns the correct type consistent with ResolveType.
+	promotedType := dt1
 	if dt1 != dt2 {
-		return nil, "", fmt.Errorf("type mismatch in numeric expression: %s vs %s", dt1, dt2)
+		promoted, ok := tsquery.PromoteNumericTypes(dt1, dt2)
+		if !ok {
+			return nil, "", fmt.Errorf("type mismatch in numeric expression: %s vs %s", dt1, dt2)
+		}
+		promotedType = promoted
 	}
 
-	funcImpl, err := n.op.GetFuncImpl(dt1)
+	// Nil propagation: if either operand is nil, result is nil with the promoted type
+	if v1 == nil || v2 == nil {
+		return nil, promotedType, nil
+	}
+
+	// Cast integer operand values to float64 (only when promotion happened)
+	if dt1 != dt2 {
+		if dt1 == tsquery.DataTypeInteger {
+			v1 = float64(v1.(int64))
+		}
+		if dt2 == tsquery.DataTypeInteger {
+			v2 = float64(v2.(int64))
+		}
+	}
+
+	// Check modulo operator constraint
+	if n.op == tsquery.BinaryNumericOperatorMod && promotedType != tsquery.DataTypeInteger {
+		return nil, "", fmt.Errorf("mod operator is only supported for integer fields. got %s", promotedType)
+	}
+
+	funcImpl, err := n.op.GetFuncImpl(promotedType)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get function for operator %s on type %s: %w", n.op, dt1, err)
+		return nil, "", fmt.Errorf("failed to get function for operator %s on type %s: %w", n.op, promotedType, err)
 	}
 
-	return funcImpl(v1, v2), dt1, nil
+	return funcImpl(v1, v2), promotedType, nil
 }
 
 func (n *NumericExpressionAggregationValue) ResolveType(sourceTypes map[string]tsquery.DataType) (tsquery.DataType, error) {
@@ -113,10 +135,22 @@ func (n *NumericExpressionAggregationValue) ResolveType(sourceTypes map[string]t
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve type for op2: %w", err)
 	}
+	// Auto-promote numeric types (int → decimal)
+	promotedType := dt1
 	if dt1 != dt2 {
-		return "", fmt.Errorf("type mismatch in numeric expression: %s vs %s", dt1, dt2)
+		promoted, ok := tsquery.PromoteNumericTypes(dt1, dt2)
+		if !ok {
+			return "", fmt.Errorf("type mismatch in numeric expression: %s vs %s", dt1, dt2)
+		}
+		promotedType = promoted
 	}
-	return dt1, nil
+
+	// Check modulo operator constraint
+	if n.op == tsquery.BinaryNumericOperatorMod && promotedType != tsquery.DataTypeInteger {
+		return "", fmt.Errorf("mod operator is only supported for integer fields. got %s", promotedType)
+	}
+
+	return promotedType, nil
 }
 
 // --- UnaryNumericOperatorAggregationValue ---

--- a/utils/timeseries/tsquery/aggregation/expression_aggregation_test.go
+++ b/utils/timeseries/tsquery/aggregation/expression_aggregation_test.go
@@ -163,21 +163,121 @@ func TestNumericExpression_NilPropagation(t *testing.T) {
 	require.Nil(t, val)
 }
 
-func TestNumericExpression_TypeMismatch(t *testing.T) {
+func TestNumericExpression_IntDecimalPromotion(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       any
+		dt1      tsquery.DataType
+		v2       any
+		dt2      tsquery.DataType
+		op       tsquery.BinaryNumericOperatorType
+		expected float64
+	}{
+		{"Add", int64(10), tsquery.DataTypeInteger, 5.5, tsquery.DataTypeDecimal, tsquery.BinaryNumericOperatorAdd, 15.5},
+		{"Sub", int64(10), tsquery.DataTypeInteger, 5.5, tsquery.DataTypeDecimal, tsquery.BinaryNumericOperatorSub, 4.5},
+		{"Mul", int64(10), tsquery.DataTypeInteger, 2.5, tsquery.DataTypeDecimal, tsquery.BinaryNumericOperatorMul, 25.0},
+		{"Div", int64(10), tsquery.DataTypeInteger, 4.0, tsquery.DataTypeDecimal, tsquery.BinaryNumericOperatorDiv, 2.5},
+		{"Pow", int64(2), tsquery.DataTypeInteger, 3.0, tsquery.DataTypeDecimal, tsquery.BinaryNumericOperatorPow, 8.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved := resolvedFields(
+				rf("a", tt.v1, tt.dt1),
+				rf("b", tt.v2, tt.dt2),
+			)
+			expr := NewNumericExpressionAggregationValue(
+				NewRefAggregationValue("a"),
+				tt.op,
+				NewRefAggregationValue("b"),
+			)
+			val, dt, err := expr.Evaluate(resolved)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, val)
+			require.Equal(t, tsquery.DataTypeDecimal, dt)
+		})
+	}
+}
+
+func TestNumericExpression_DecimalIntPromotion(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       any
+		dt1      tsquery.DataType
+		v2       any
+		dt2      tsquery.DataType
+		op       tsquery.BinaryNumericOperatorType
+		expected float64
+	}{
+		{"Add", 5.5, tsquery.DataTypeDecimal, int64(10), tsquery.DataTypeInteger, tsquery.BinaryNumericOperatorAdd, 15.5},
+		{"Sub", 10.5, tsquery.DataTypeDecimal, int64(5), tsquery.DataTypeInteger, tsquery.BinaryNumericOperatorSub, 5.5},
+		{"Mul", 2.5, tsquery.DataTypeDecimal, int64(10), tsquery.DataTypeInteger, tsquery.BinaryNumericOperatorMul, 25.0},
+		{"Div", 10.0, tsquery.DataTypeDecimal, int64(4), tsquery.DataTypeInteger, tsquery.BinaryNumericOperatorDiv, 2.5},
+		{"Pow", 2.0, tsquery.DataTypeDecimal, int64(3), tsquery.DataTypeInteger, tsquery.BinaryNumericOperatorPow, 8.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved := resolvedFields(
+				rf("a", tt.v1, tt.dt1),
+				rf("b", tt.v2, tt.dt2),
+			)
+			expr := NewNumericExpressionAggregationValue(
+				NewRefAggregationValue("a"),
+				tt.op,
+				NewRefAggregationValue("b"),
+			)
+			val, dt, err := expr.Evaluate(resolved)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, val)
+			require.Equal(t, tsquery.DataTypeDecimal, dt)
+		})
+	}
+}
+
+func TestNumericExpression_IntDecimalPromotion_OutputType(t *testing.T) {
 	resolved := resolvedFields(
 		rf("a", int64(10), tsquery.DataTypeInteger),
 		rf("b", 5.0, tsquery.DataTypeDecimal),
 	)
-
 	expr := NewNumericExpressionAggregationValue(
 		NewRefAggregationValue("a"),
 		tsquery.BinaryNumericOperatorAdd,
 		NewRefAggregationValue("b"),
 	)
+	_, dt, err := expr.Evaluate(resolved)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeDecimal, dt)
+}
 
+func TestNumericExpression_IntDecimalModulo_Error(t *testing.T) {
+	resolved := resolvedFields(
+		rf("a", int64(10), tsquery.DataTypeInteger),
+		rf("b", 3.0, tsquery.DataTypeDecimal),
+	)
+	expr := NewNumericExpressionAggregationValue(
+		NewRefAggregationValue("a"),
+		tsquery.BinaryNumericOperatorMod,
+		NewRefAggregationValue("b"),
+	)
 	_, _, err := expr.Evaluate(resolved)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "type mismatch")
+	require.Contains(t, err.Error(), "mod operator is only supported for integer fields")
+}
+
+func TestNumericExpression_IntDecimalPromotion_NilPropagation(t *testing.T) {
+	resolved := resolvedFields(
+		rf("a", nil, tsquery.DataTypeInteger),
+		rf("b", 5.0, tsquery.DataTypeDecimal),
+	)
+	expr := NewNumericExpressionAggregationValue(
+		NewRefAggregationValue("a"),
+		tsquery.BinaryNumericOperatorAdd,
+		NewRefAggregationValue("b"),
+	)
+	val, _, err := expr.Evaluate(resolved)
+	require.NoError(t, err)
+	require.Nil(t, val)
 }
 
 // --- UnaryNumericOperatorAggregationValue tests ---
@@ -417,7 +517,7 @@ func TestResolveType_NumericExpression_SameTypes(t *testing.T) {
 	require.Equal(t, tsquery.DataTypeInteger, dt)
 }
 
-func TestResolveType_NumericExpression_TypeMismatch(t *testing.T) {
+func TestResolveType_IntDecimalPromotion(t *testing.T) {
 	sourceTypes := map[string]tsquery.DataType{
 		"a": tsquery.DataTypeInteger,
 		"b": tsquery.DataTypeDecimal,
@@ -427,9 +527,24 @@ func TestResolveType_NumericExpression_TypeMismatch(t *testing.T) {
 		tsquery.BinaryNumericOperatorAdd,
 		NewRefAggregationValue("b"),
 	)
+	dt, err := expr.ResolveType(sourceTypes)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeDecimal, dt)
+}
+
+func TestResolveType_IntDecimalModulo_Error(t *testing.T) {
+	sourceTypes := map[string]tsquery.DataType{
+		"a": tsquery.DataTypeInteger,
+		"b": tsquery.DataTypeDecimal,
+	}
+	expr := NewNumericExpressionAggregationValue(
+		NewRefAggregationValue("a"),
+		tsquery.BinaryNumericOperatorMod,
+		NewRefAggregationValue("b"),
+	)
 	_, err := expr.ResolveType(sourceTypes)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "type mismatch")
+	require.Contains(t, err.Error(), "mod operator is only supported for integer fields")
 }
 
 func TestResolveType_UnaryOperator(t *testing.T) {
@@ -579,4 +694,149 @@ func TestExpressionAggregation_EmptySource(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, fields, 1)
 	require.Nil(t, fields[0].Value, "nil source value should propagate through expression")
+}
+
+// --- Nil propagation type correctness (MISSING 1) ---
+
+func TestNumericExpression_IntDecimalPromotion_NilType(t *testing.T) {
+	// When nil propagates through a mixed int+decimal expression,
+	// the returned DataType must be decimal (matching ResolveType).
+	tests := []struct {
+		name string
+		v1   any
+		dt1  tsquery.DataType
+		v2   any
+		dt2  tsquery.DataType
+	}{
+		{"int_nil+decimal", nil, tsquery.DataTypeInteger, 5.0, tsquery.DataTypeDecimal},
+		{"int+decimal_nil", int64(5), tsquery.DataTypeInteger, nil, tsquery.DataTypeDecimal},
+		{"decimal_nil+int", nil, tsquery.DataTypeDecimal, int64(5), tsquery.DataTypeInteger},
+		{"decimal+int_nil", 5.0, tsquery.DataTypeDecimal, nil, tsquery.DataTypeInteger},
+		{"both_nil_int_decimal", nil, tsquery.DataTypeInteger, nil, tsquery.DataTypeDecimal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved := resolvedFields(
+				rf("a", tt.v1, tt.dt1),
+				rf("b", tt.v2, tt.dt2),
+			)
+			expr := NewNumericExpressionAggregationValue(
+				NewRefAggregationValue("a"),
+				tsquery.BinaryNumericOperatorAdd,
+				NewRefAggregationValue("b"),
+			)
+			val, dt, err := expr.Evaluate(resolved)
+			require.NoError(t, err)
+			require.Nil(t, val)
+			require.Equal(t, tsquery.DataTypeDecimal, dt, "nil propagation must return promoted type")
+		})
+	}
+}
+
+// --- Modulo error tests (MISSING 2 & 3) ---
+
+func TestNumericExpression_DecimalIntModulo_Error(t *testing.T) {
+	resolved := resolvedFields(
+		rf("a", 10.0, tsquery.DataTypeDecimal),
+		rf("b", int64(3), tsquery.DataTypeInteger),
+	)
+	expr := NewNumericExpressionAggregationValue(
+		NewRefAggregationValue("a"),
+		tsquery.BinaryNumericOperatorMod,
+		NewRefAggregationValue("b"),
+	)
+	_, _, err := expr.Evaluate(resolved)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mod operator is only supported for integer fields")
+}
+
+func TestNumericExpression_DecimalDecimalModulo_Error(t *testing.T) {
+	resolved := resolvedFields(
+		rf("a", 10.0, tsquery.DataTypeDecimal),
+		rf("b", 3.0, tsquery.DataTypeDecimal),
+	)
+	expr := NewNumericExpressionAggregationValue(
+		NewRefAggregationValue("a"),
+		tsquery.BinaryNumericOperatorMod,
+		NewRefAggregationValue("b"),
+	)
+	_, _, err := expr.Evaluate(resolved)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mod operator is only supported for integer fields")
+}
+
+// --- Evaluate/ResolveType consistency (MISSING 4) ---
+
+func TestNumericExpression_EvaluateResolveTypeConsistency(t *testing.T) {
+	// For each operator with mixed int+decimal operands, Evaluate and ResolveType
+	// must agree on the returned DataType.
+	operators := []tsquery.BinaryNumericOperatorType{
+		tsquery.BinaryNumericOperatorAdd,
+		tsquery.BinaryNumericOperatorSub,
+		tsquery.BinaryNumericOperatorMul,
+		tsquery.BinaryNumericOperatorDiv,
+		tsquery.BinaryNumericOperatorPow,
+	}
+
+	sourceTypes := map[string]tsquery.DataType{
+		"a": tsquery.DataTypeInteger,
+		"b": tsquery.DataTypeDecimal,
+	}
+	resolved := resolvedFields(
+		rf("a", int64(10), tsquery.DataTypeInteger),
+		rf("b", 5.0, tsquery.DataTypeDecimal),
+	)
+
+	for _, op := range operators {
+		t.Run(string(op), func(t *testing.T) {
+			expr := NewNumericExpressionAggregationValue(
+				NewRefAggregationValue("a"),
+				op,
+				NewRefAggregationValue("b"),
+			)
+
+			resolvedType, err := expr.ResolveType(sourceTypes)
+			require.NoError(t, err)
+
+			_, evalType, err := expr.Evaluate(resolved)
+			require.NoError(t, err)
+
+			require.Equal(t, resolvedType, evalType, "Evaluate and ResolveType must return the same DataType")
+		})
+	}
+}
+
+// --- Reviewer suggestions: same-type nil propagation type assertion ---
+
+func TestNumericExpression_NilPropagation_ReturnsCorrectType(t *testing.T) {
+	resolved := resolvedFields(
+		rf("a", nil, tsquery.DataTypeInteger),
+		rf("b", int64(5), tsquery.DataTypeInteger),
+	)
+	expr := NewNumericExpressionAggregationValue(
+		NewRefAggregationValue("a"),
+		tsquery.BinaryNumericOperatorAdd,
+		NewRefAggregationValue("b"),
+	)
+	val, dt, err := expr.Evaluate(resolved)
+	require.NoError(t, err)
+	require.Nil(t, val)
+	require.Equal(t, tsquery.DataTypeInteger, dt, "same-type nil propagation should return integer")
+}
+
+// --- Reviewer suggestion: ResolveType decimal+int (reverse direction) ---
+
+func TestResolveType_DecimalIntPromotion(t *testing.T) {
+	sourceTypes := map[string]tsquery.DataType{
+		"a": tsquery.DataTypeDecimal,
+		"b": tsquery.DataTypeInteger,
+	}
+	expr := NewNumericExpressionAggregationValue(
+		NewRefAggregationValue("a"),
+		tsquery.BinaryNumericOperatorAdd,
+		NewRefAggregationValue("b"),
+	)
+	dt, err := expr.ResolveType(sourceTypes)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeDecimal, dt)
 }

--- a/utils/timeseries/tsquery/datasource/condition_field_value.go
+++ b/utils/timeseries/tsquery/datasource/condition_field_value.go
@@ -38,17 +38,43 @@ func (cf ConditionFieldValue) Execute(ctx context.Context, fieldMeta tsquery.Fie
 	dt1 := operand1Meta.DataType
 	dt2 := operand2Meta.DataType
 
-	// Check that both operands have the same data type
+	// Auto-promote numeric types (int → decimal)
+	resolvedType := dt1
 	if dt1 != dt2 {
-		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
-			"operand types do not match: %s vs %s when executing condition field",
-			dt1,
-			dt2,
-		)
+		promoted, ok := tsquery.PromoteNumericTypes(dt1, dt2)
+		if !ok {
+			return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
+				"operand types do not match: %s vs %s when executing condition field",
+				dt1,
+				dt2,
+			)
+		}
+		resolvedType = promoted
+		// Wrap the integer operand's supplier to cast int64 → float64
+		if dt1 == tsquery.DataTypeInteger {
+			orig := operand1Supplier
+			operand1Supplier = func(ctx context.Context, currRow timeseries.TsRecord[any]) (any, error) {
+				v, err := orig(ctx, currRow)
+				if err != nil || v == nil {
+					return v, err
+				}
+				return float64(v.(int64)), nil
+			}
+		}
+		if dt2 == tsquery.DataTypeInteger {
+			orig := operand2Supplier
+			operand2Supplier = func(ctx context.Context, currRow timeseries.TsRecord[any]) (any, error) {
+				v, err := orig(ctx, currRow)
+				if err != nil || v == nil {
+					return v, err
+				}
+				return float64(v.(int64)), nil
+			}
+		}
 	}
 
 	// Get the comparison function implementation
-	compareFunc, err := cf.operatorType.GetFuncImpl(dt1)
+	compareFunc, err := cf.operatorType.GetFuncImpl(resolvedType)
 	if err != nil {
 		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("failed to get comparison function: %w", err)
 	}

--- a/utils/timeseries/tsquery/datasource/condition_field_value_test.go
+++ b/utils/timeseries/tsquery/datasource/condition_field_value_test.go
@@ -1,0 +1,132 @@
+package datasource
+
+import (
+	"context"
+	"github.com/shpandrak/shpanstream/utils/timeseries"
+	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func executeConditionAndGetValue(ctx context.Context, f Value) (any, error) {
+	_, valueSupplier, err := f.Execute(ctx, tsquery.FieldMeta{})
+	if err != nil {
+		return nil, err
+	}
+	dummyRow := timeseries.TsRecord[any]{Timestamp: time.Now(), Value: nil}
+	return valueSupplier(ctx, dummyRow)
+}
+
+func TestConditionField_IntDecimalComparison(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+
+	tests := []struct {
+		name     string
+		v1       any
+		v1Meta   tsquery.ValueMeta
+		v2       any
+		v2Meta   tsquery.ValueMeta
+		op       tsquery.ConditionOperatorType
+		expected bool
+	}{
+		{"Equals_true", int64(10), intMeta, 10.0, decMeta, tsquery.ConditionOperatorEquals, true},
+		{"NotEquals_false", int64(10), intMeta, 10.0, decMeta, tsquery.ConditionOperatorNotEquals, false},
+		{"GreaterThan_true", int64(10), intMeta, 5.5, decMeta, tsquery.ConditionOperatorGreaterThan, true},
+		{"LessThan_true", int64(5), intMeta, 5.5, decMeta, tsquery.ConditionOperatorLessThan, true},
+		{"GreaterEqual_true", int64(10), intMeta, 10.0, decMeta, tsquery.ConditionOperatorGreaterEqual, true},
+		{"LessEqual_true", int64(5), intMeta, 5.5, decMeta, tsquery.ConditionOperatorLessEqual, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field1 := NewConstantFieldValue(tt.v1Meta, tt.v1)
+			field2 := NewConstantFieldValue(tt.v2Meta, tt.v2)
+
+			cond := NewConditionFieldValue(tt.op, field1, field2)
+			result, err := executeConditionAndGetValue(ctx, cond)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConditionField_DecimalIntComparison(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+
+	tests := []struct {
+		name     string
+		v1       any
+		v1Meta   tsquery.ValueMeta
+		v2       any
+		v2Meta   tsquery.ValueMeta
+		op       tsquery.ConditionOperatorType
+		expected bool
+	}{
+		{"Equals_true", 10.0, decMeta, int64(10), intMeta, tsquery.ConditionOperatorEquals, true},
+		{"NotEquals_true", 10.5, decMeta, int64(10), intMeta, tsquery.ConditionOperatorNotEquals, true},
+		{"GreaterThan_true", 10.5, decMeta, int64(10), intMeta, tsquery.ConditionOperatorGreaterThan, true},
+		{"LessThan_true", 4.5, decMeta, int64(5), intMeta, tsquery.ConditionOperatorLessThan, true},
+		{"GreaterEqual_true", 10.0, decMeta, int64(10), intMeta, tsquery.ConditionOperatorGreaterEqual, true},
+		{"LessEqual_true", 5.0, decMeta, int64(5), intMeta, tsquery.ConditionOperatorLessEqual, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field1 := NewConstantFieldValue(tt.v1Meta, tt.v1)
+			field2 := NewConstantFieldValue(tt.v2Meta, tt.v2)
+
+			cond := NewConditionFieldValue(tt.op, field1, field2)
+			result, err := executeConditionAndGetValue(ctx, cond)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConditionField_IntDecimalComparison_OutputMeta(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+
+	field1 := NewConstantFieldValue(intMeta, int64(10))
+	field2 := NewConstantFieldValue(decMeta, 5.5)
+
+	cond := NewConditionFieldValue(tsquery.ConditionOperatorEquals, field1, field2)
+	meta, _, err := cond.Execute(ctx, tsquery.FieldMeta{})
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeBoolean, meta.DataType)
+}
+
+func TestConditionField_NonNumericMismatch_StillErrors(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}
+	strMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeString, Required: true}
+
+	field1 := NewConstantFieldValue(strMeta, "hello")
+	field2 := NewConstantFieldValue(intMeta, int64(10))
+
+	cond := NewConditionFieldValue(tsquery.ConditionOperatorEquals, field1, field2)
+	_, _, err := cond.Execute(ctx, tsquery.FieldMeta{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "operand types do not match")
+}
+
+func TestConditionField_IntDecimalComparison_WithOptionalOperands(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	// nil handling: nil compared to any value returns false
+	field1 := NewConstantFieldValue(intMeta, nil)
+	field2 := NewConstantFieldValue(decMeta, 5.5)
+
+	cond := NewConditionFieldValue(tsquery.ConditionOperatorEquals, field1, field2)
+	result, err := executeConditionAndGetValue(ctx, cond)
+	require.NoError(t, err)
+	require.Equal(t, false, result)
+}

--- a/utils/timeseries/tsquery/datasource/numeric_expression_field_value.go
+++ b/utils/timeseries/tsquery/datasource/numeric_expression_field_value.go
@@ -50,23 +50,49 @@ func (nef NumericExpressionFieldValue) Execute(ctx context.Context, fieldMeta ts
 		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("op2 field has non-numeric data type: %s", dt2)
 	}
 
-	// Check that both operands have the same data type
+	// Auto-promote numeric types (int → decimal)
+	promotedType := dt1
 	if dt1 != dt2 {
-		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
-			"incompatible datatypes for fields : %s %s %s",
-			dt1,
-			nef.op,
-			dt2,
-		)
+		promoted, ok := tsquery.PromoteNumericTypes(dt1, dt2)
+		if !ok {
+			return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
+				"incompatible datatypes for fields : %s %s %s",
+				dt1,
+				nef.op,
+				dt2,
+			)
+		}
+		promotedType = promoted
+		// Wrap the integer operand's supplier to cast int64 → float64
+		if dt1 == tsquery.DataTypeInteger {
+			orig := op1ValueSupplier
+			op1ValueSupplier = func(ctx context.Context, currRow timeseries.TsRecord[any]) (any, error) {
+				v, err := orig(ctx, currRow)
+				if err != nil || v == nil {
+					return v, err
+				}
+				return float64(v.(int64)), nil
+			}
+		}
+		if dt2 == tsquery.DataTypeInteger {
+			orig := op2ValueSupplier
+			op2ValueSupplier = func(ctx context.Context, currRow timeseries.TsRecord[any]) (any, error) {
+				v, err := orig(ctx, currRow)
+				if err != nil || v == nil {
+					return v, err
+				}
+				return float64(v.(int64)), nil
+			}
+		}
 	}
 
 	// Check modulo operator constraint
-	if nef.op == tsquery.BinaryNumericOperatorMod && dt1 != tsquery.DataTypeInteger {
-		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("mod operator is only supported for integer fields. got %s", dt1)
+	if nef.op == tsquery.BinaryNumericOperatorMod && promotedType != tsquery.DataTypeInteger {
+		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("mod operator is only supported for integer fields. got %s", promotedType)
 	}
 
 	// Get the function implementation
-	funcImpl, err := nef.op.GetFuncImpl(dt1)
+	funcImpl, err := nef.op.GetFuncImpl(promotedType)
 	if err != nil {
 		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("failed to get function implementation: %w", err)
 	}
@@ -78,7 +104,7 @@ func (nef NumericExpressionFieldValue) Execute(ctx context.Context, fieldMeta ts
 
 	// Merge CustomMeta from both operands, op1 takes precedence on conflicts
 	fvm := tsquery.ValueMeta{
-		DataType:   dt1,
+		DataType:   promotedType,
 		Unit:       updatedUnit,
 		Required:   op1Meta.Required && op2Meta.Required,
 		CustomMeta: tsquery.MergeCustomMeta(op2Meta.CustomMeta, op1Meta.CustomMeta),

--- a/utils/timeseries/tsquery/datasource/numeric_expression_field_value_test.go
+++ b/utils/timeseries/tsquery/datasource/numeric_expression_field_value_test.go
@@ -111,7 +111,75 @@ func TestNumericExpressionField_DecimalOperations(t *testing.T) {
 	}
 }
 
-func TestNumericExpressionField_IncompatibleTypes(t *testing.T) {
+func TestNumericExpressionField_IntDecimalPromotion(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	tests := []struct {
+		name     string
+		v1       any
+		v1Meta   tsquery.ValueMeta
+		v2       any
+		v2Meta   tsquery.ValueMeta
+		operator tsquery.BinaryNumericOperatorType
+		expected float64
+	}{
+		{"Add", int64(10), intMeta, 5.5, decMeta, tsquery.BinaryNumericOperatorAdd, 15.5},
+		{"Sub", int64(10), intMeta, 5.5, decMeta, tsquery.BinaryNumericOperatorSub, 4.5},
+		{"Mul", int64(10), intMeta, 2.5, decMeta, tsquery.BinaryNumericOperatorMul, 25.0},
+		{"Div", int64(10), intMeta, 4.0, decMeta, tsquery.BinaryNumericOperatorDiv, 2.5},
+		{"Pow", int64(2), intMeta, 3.0, decMeta, tsquery.BinaryNumericOperatorPow, 8.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field1 := NewConstantFieldValue(tt.v1Meta, tt.v1)
+			field2 := NewConstantFieldValue(tt.v2Meta, tt.v2)
+
+			expr := NewNumericExpressionFieldValue(field1, tt.operator, field2)
+			result, err := executeAndGetValueForNumericTest(ctx, expr)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNumericExpressionField_DecimalIntPromotion(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	tests := []struct {
+		name     string
+		v1       any
+		v1Meta   tsquery.ValueMeta
+		v2       any
+		v2Meta   tsquery.ValueMeta
+		operator tsquery.BinaryNumericOperatorType
+		expected float64
+	}{
+		{"Add", 5.5, decMeta, int64(10), intMeta, tsquery.BinaryNumericOperatorAdd, 15.5},
+		{"Sub", 10.5, decMeta, int64(5), intMeta, tsquery.BinaryNumericOperatorSub, 5.5},
+		{"Mul", 2.5, decMeta, int64(10), intMeta, tsquery.BinaryNumericOperatorMul, 25.0},
+		{"Div", 10.0, decMeta, int64(4), intMeta, tsquery.BinaryNumericOperatorDiv, 2.5},
+		{"Pow", 2.0, decMeta, int64(3), intMeta, tsquery.BinaryNumericOperatorPow, 8.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field1 := NewConstantFieldValue(tt.v1Meta, tt.v1)
+			field2 := NewConstantFieldValue(tt.v2Meta, tt.v2)
+
+			expr := NewNumericExpressionFieldValue(field1, tt.operator, field2)
+			result, err := executeAndGetValueForNumericTest(ctx, expr)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNumericExpressionField_IntDecimalPromotion_OutputType(t *testing.T) {
 	ctx := context.Background()
 	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
 	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
@@ -120,9 +188,73 @@ func TestNumericExpressionField_IncompatibleTypes(t *testing.T) {
 	field2 := NewConstantFieldValue(decMeta, 5.5)
 
 	expr := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorAdd, field2)
+	exprMeta, err := executeAndGetMetaForNumericTest(ctx, expr)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeDecimal, exprMeta.DataType)
+}
+
+func TestNumericExpressionField_IntDecimalModulo_Error(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	field1 := NewConstantFieldValue(intMeta, int64(10))
+	field2 := NewConstantFieldValue(decMeta, 3.0)
+
+	expr := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorMod, field2)
 	_, _, err := expr.Execute(ctx, tsquery.FieldMeta{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "incompatible datatypes")
+	require.Contains(t, err.Error(), "mod operator is only supported for integer fields")
+}
+
+func TestNumericExpressionField_DecimalIntModulo_Error(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	field1 := NewConstantFieldValue(decMeta, 10.0)
+	field2 := NewConstantFieldValue(intMeta, int64(3))
+
+	expr := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorMod, field2)
+	_, _, err := expr.Execute(ctx, tsquery.FieldMeta{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mod operator is only supported for integer fields")
+}
+
+func TestNumericExpressionField_IntDecimalPromotion_Chained(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	// (int + decimal) * int → decimal
+	field1 := NewConstantFieldValue(intMeta, int64(10))
+	field2 := NewConstantFieldValue(decMeta, 5.5)
+	field3 := NewConstantFieldValue(intMeta, int64(2))
+
+	expr1 := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorAdd, field2)
+	expr2 := NewNumericExpressionFieldValue(expr1, tsquery.BinaryNumericOperatorMul, field3)
+
+	result, err := executeAndGetValueForNumericTest(ctx, expr2)
+	require.NoError(t, err)
+	require.Equal(t, float64(31.0), result)
+
+	exprMeta, err := executeAndGetMetaForNumericTest(ctx, expr2)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeDecimal, exprMeta.DataType)
+}
+
+func TestNumericExpressionField_IntDecimalPromotion_OptionalNil(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	field1 := NewConstantFieldValue(intMeta, nil)
+	field2 := NewConstantFieldValue(decMeta, 5.5)
+
+	expr := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorAdd, field2)
+	result, err := executeAndGetValueForNumericTest(ctx, expr)
+	require.NoError(t, err)
+	require.Nil(t, result)
 }
 
 func TestNumericExpressionField_NonNumericTypes(t *testing.T) {

--- a/utils/timeseries/tsquery/datatype.go
+++ b/utils/timeseries/tsquery/datatype.go
@@ -81,6 +81,19 @@ func (dt DataType) IsNumeric() bool {
 	return dt == DataTypeInteger || dt == DataTypeDecimal
 }
 
+// PromoteNumericTypes returns the promoted type when both types are numeric.
+// Returns (promoted type, needs promotion). If types are equal or not both numeric,
+// needsPromotion is false.
+func PromoteNumericTypes(dt1, dt2 DataType) (DataType, bool) {
+	if dt1 == dt2 {
+		return dt1, false
+	}
+	if dt1.IsNumeric() && dt2.IsNumeric() {
+		return DataTypeDecimal, true
+	}
+	return dt1, false
+}
+
 func (dt DataType) ToFloat64(val any) (float64, error) {
 	switch dt {
 	case DataTypeInteger:

--- a/utils/timeseries/tsquery/report/condition_report_field_value.go
+++ b/utils/timeseries/tsquery/report/condition_report_field_value.go
@@ -41,17 +41,43 @@ func (cf ConditionFieldValue) Execute(
 	dt1 := operand1Meta.DataType
 	dt2 := operand2Meta.DataType
 
-	// Check that both operands have the same data type
+	// Auto-promote numeric types (int → decimal)
+	resolvedType := dt1
 	if dt1 != dt2 {
-		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
-			"operand types do not match: %s vs %s when executing condition field",
-			dt1,
-			dt2,
-		)
+		promoted, ok := tsquery.PromoteNumericTypes(dt1, dt2)
+		if !ok {
+			return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
+				"operand types do not match: %s vs %s when executing condition field",
+				dt1,
+				dt2,
+			)
+		}
+		resolvedType = promoted
+		// Wrap the integer operand's supplier to cast int64 → float64
+		if dt1 == tsquery.DataTypeInteger {
+			orig := operand1Supplier
+			operand1Supplier = func(ctx context.Context, currRow timeseries.TsRecord[[]any]) (any, error) {
+				v, err := orig(ctx, currRow)
+				if err != nil || v == nil {
+					return v, err
+				}
+				return float64(v.(int64)), nil
+			}
+		}
+		if dt2 == tsquery.DataTypeInteger {
+			orig := operand2Supplier
+			operand2Supplier = func(ctx context.Context, currRow timeseries.TsRecord[[]any]) (any, error) {
+				v, err := orig(ctx, currRow)
+				if err != nil || v == nil {
+					return v, err
+				}
+				return float64(v.(int64)), nil
+			}
+		}
 	}
 
 	// Get the comparison function implementation
-	compareFunc, err := cf.operatorType.GetFuncImpl(dt1)
+	compareFunc, err := cf.operatorType.GetFuncImpl(resolvedType)
 	if err != nil {
 		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("failed to get comparison function: %w", err)
 	}

--- a/utils/timeseries/tsquery/report/condition_report_field_value_test.go
+++ b/utils/timeseries/tsquery/report/condition_report_field_value_test.go
@@ -1,0 +1,132 @@
+package report
+
+import (
+	"context"
+	"github.com/shpandrak/shpanstream/utils/timeseries"
+	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func executeConditionAndGetValue(ctx context.Context, f Value) (any, error) {
+	_, valueSupplier, err := f.Execute(ctx, []tsquery.FieldMeta{})
+	if err != nil {
+		return nil, err
+	}
+	dummyRow := timeseries.TsRecord[[]any]{Timestamp: time.Now(), Value: []any{}}
+	return valueSupplier(ctx, dummyRow)
+}
+
+func TestConditionField_IntDecimalComparison(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+
+	tests := []struct {
+		name     string
+		v1       any
+		v1Meta   tsquery.ValueMeta
+		v2       any
+		v2Meta   tsquery.ValueMeta
+		op       tsquery.ConditionOperatorType
+		expected bool
+	}{
+		{"Equals_true", int64(10), intMeta, 10.0, decMeta, tsquery.ConditionOperatorEquals, true},
+		{"NotEquals_false", int64(10), intMeta, 10.0, decMeta, tsquery.ConditionOperatorNotEquals, false},
+		{"GreaterThan_true", int64(10), intMeta, 5.5, decMeta, tsquery.ConditionOperatorGreaterThan, true},
+		{"LessThan_true", int64(5), intMeta, 5.5, decMeta, tsquery.ConditionOperatorLessThan, true},
+		{"GreaterEqual_true", int64(10), intMeta, 10.0, decMeta, tsquery.ConditionOperatorGreaterEqual, true},
+		{"LessEqual_true", int64(5), intMeta, 5.5, decMeta, tsquery.ConditionOperatorLessEqual, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field1 := NewConstantFieldValue(tt.v1Meta, tt.v1)
+			field2 := NewConstantFieldValue(tt.v2Meta, tt.v2)
+
+			cond := NewConditionFieldValue(tt.op, field1, field2)
+			result, err := executeConditionAndGetValue(ctx, cond)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConditionField_DecimalIntComparison(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+
+	tests := []struct {
+		name     string
+		v1       any
+		v1Meta   tsquery.ValueMeta
+		v2       any
+		v2Meta   tsquery.ValueMeta
+		op       tsquery.ConditionOperatorType
+		expected bool
+	}{
+		{"Equals_true", 10.0, decMeta, int64(10), intMeta, tsquery.ConditionOperatorEquals, true},
+		{"NotEquals_true", 10.5, decMeta, int64(10), intMeta, tsquery.ConditionOperatorNotEquals, true},
+		{"GreaterThan_true", 10.5, decMeta, int64(10), intMeta, tsquery.ConditionOperatorGreaterThan, true},
+		{"LessThan_true", 4.5, decMeta, int64(5), intMeta, tsquery.ConditionOperatorLessThan, true},
+		{"GreaterEqual_true", 10.0, decMeta, int64(10), intMeta, tsquery.ConditionOperatorGreaterEqual, true},
+		{"LessEqual_true", 5.0, decMeta, int64(5), intMeta, tsquery.ConditionOperatorLessEqual, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field1 := NewConstantFieldValue(tt.v1Meta, tt.v1)
+			field2 := NewConstantFieldValue(tt.v2Meta, tt.v2)
+
+			cond := NewConditionFieldValue(tt.op, field1, field2)
+			result, err := executeConditionAndGetValue(ctx, cond)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConditionField_IntDecimalComparison_OutputMeta(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+
+	field1 := NewConstantFieldValue(intMeta, int64(10))
+	field2 := NewConstantFieldValue(decMeta, 5.5)
+
+	cond := NewConditionFieldValue(tsquery.ConditionOperatorEquals, field1, field2)
+	meta, _, err := cond.Execute(ctx, []tsquery.FieldMeta{})
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeBoolean, meta.DataType)
+}
+
+func TestConditionField_NonNumericMismatch_StillErrors(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: true}
+	strMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeString, Required: true}
+
+	field1 := NewConstantFieldValue(strMeta, "hello")
+	field2 := NewConstantFieldValue(intMeta, int64(10))
+
+	cond := NewConditionFieldValue(tsquery.ConditionOperatorEquals, field1, field2)
+	_, _, err := cond.Execute(ctx, []tsquery.FieldMeta{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "operand types do not match")
+}
+
+func TestConditionField_IntDecimalComparison_WithOptionalOperands(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	// nil handling: nil compared to any value returns false
+	field1 := NewConstantFieldValue(intMeta, nil)
+	field2 := NewConstantFieldValue(decMeta, 5.5)
+
+	cond := NewConditionFieldValue(tsquery.ConditionOperatorEquals, field1, field2)
+	result, err := executeConditionAndGetValue(ctx, cond)
+	require.NoError(t, err)
+	require.Equal(t, false, result)
+}

--- a/utils/timeseries/tsquery/report/numeric_expression_report_field_value.go
+++ b/utils/timeseries/tsquery/report/numeric_expression_report_field_value.go
@@ -50,23 +50,49 @@ func (nef NumericExpressionFieldValue) Execute(ctx context.Context, fieldsMeta [
 		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("op2 field has non-numeric data type: %s", dt2)
 	}
 
-	// Check that both operands have the same data type
+	// Auto-promote numeric types (int → decimal)
+	promotedType := dt1
 	if dt1 != dt2 {
-		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
-			"incompatible datatypes for fields : %s %s %s",
-			dt1,
-			nef.op,
-			dt2,
-		)
+		promoted, ok := tsquery.PromoteNumericTypes(dt1, dt2)
+		if !ok {
+			return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
+				"incompatible datatypes for fields : %s %s %s",
+				dt1,
+				nef.op,
+				dt2,
+			)
+		}
+		promotedType = promoted
+		// Wrap the integer operand's supplier to cast int64 → float64
+		if dt1 == tsquery.DataTypeInteger {
+			orig := op1ValueSupplier
+			op1ValueSupplier = func(ctx context.Context, currRow timeseries.TsRecord[[]any]) (any, error) {
+				v, err := orig(ctx, currRow)
+				if err != nil || v == nil {
+					return v, err
+				}
+				return float64(v.(int64)), nil
+			}
+		}
+		if dt2 == tsquery.DataTypeInteger {
+			orig := op2ValueSupplier
+			op2ValueSupplier = func(ctx context.Context, currRow timeseries.TsRecord[[]any]) (any, error) {
+				v, err := orig(ctx, currRow)
+				if err != nil || v == nil {
+					return v, err
+				}
+				return float64(v.(int64)), nil
+			}
+		}
 	}
 
 	// Check modulo operator constraint
-	if nef.op == tsquery.BinaryNumericOperatorMod && dt1 != tsquery.DataTypeInteger {
-		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("mod operator is only supported for integer fields. got %s", dt1)
+	if nef.op == tsquery.BinaryNumericOperatorMod && promotedType != tsquery.DataTypeInteger {
+		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("mod operator is only supported for integer fields. got %s", promotedType)
 	}
 
 	// Get the function implementation
-	funcImpl, err := nef.op.GetFuncImpl(dt1)
+	funcImpl, err := nef.op.GetFuncImpl(promotedType)
 	if err != nil {
 		return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf("failed to get function implementation: %w", err)
 	}
@@ -78,7 +104,7 @@ func (nef NumericExpressionFieldValue) Execute(ctx context.Context, fieldsMeta [
 
 	// Merge CustomMeta from both operands, op1 takes precedence on conflicts
 	fvm := tsquery.ValueMeta{
-		DataType:   dt1,
+		DataType:   promotedType,
 		Unit:       updatedUnit,
 		Required:   op1Meta.Required && op2Meta.Required,
 		CustomMeta: tsquery.MergeCustomMeta(op2Meta.CustomMeta, op1Meta.CustomMeta),

--- a/utils/timeseries/tsquery/report/numeric_expression_report_field_value_test.go
+++ b/utils/timeseries/tsquery/report/numeric_expression_report_field_value_test.go
@@ -112,7 +112,75 @@ func TestNumericExpressionField_DecimalOperations(t *testing.T) {
 	}
 }
 
-func TestNumericExpressionField_IncompatibleTypes(t *testing.T) {
+func TestNumericExpressionField_IntDecimalPromotion(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	tests := []struct {
+		name     string
+		v1       any
+		v1Meta   tsquery.ValueMeta
+		v2       any
+		v2Meta   tsquery.ValueMeta
+		operator tsquery.BinaryNumericOperatorType
+		expected float64
+	}{
+		{"Add", int64(10), intMeta, 5.5, decMeta, tsquery.BinaryNumericOperatorAdd, 15.5},
+		{"Sub", int64(10), intMeta, 5.5, decMeta, tsquery.BinaryNumericOperatorSub, 4.5},
+		{"Mul", int64(10), intMeta, 2.5, decMeta, tsquery.BinaryNumericOperatorMul, 25.0},
+		{"Div", int64(10), intMeta, 4.0, decMeta, tsquery.BinaryNumericOperatorDiv, 2.5},
+		{"Pow", int64(2), intMeta, 3.0, decMeta, tsquery.BinaryNumericOperatorPow, 8.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field1 := NewConstantFieldValue(tt.v1Meta, tt.v1)
+			field2 := NewConstantFieldValue(tt.v2Meta, tt.v2)
+
+			expr := NewNumericExpressionFieldValue(field1, tt.operator, field2)
+			result, err := executeAndGetValueForNumericTest(t, expr, ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNumericExpressionField_DecimalIntPromotion(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	tests := []struct {
+		name     string
+		v1       any
+		v1Meta   tsquery.ValueMeta
+		v2       any
+		v2Meta   tsquery.ValueMeta
+		operator tsquery.BinaryNumericOperatorType
+		expected float64
+	}{
+		{"Add", 5.5, decMeta, int64(10), intMeta, tsquery.BinaryNumericOperatorAdd, 15.5},
+		{"Sub", 10.5, decMeta, int64(5), intMeta, tsquery.BinaryNumericOperatorSub, 5.5},
+		{"Mul", 2.5, decMeta, int64(10), intMeta, tsquery.BinaryNumericOperatorMul, 25.0},
+		{"Div", 10.0, decMeta, int64(4), intMeta, tsquery.BinaryNumericOperatorDiv, 2.5},
+		{"Pow", 2.0, decMeta, int64(3), intMeta, tsquery.BinaryNumericOperatorPow, 8.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field1 := NewConstantFieldValue(tt.v1Meta, tt.v1)
+			field2 := NewConstantFieldValue(tt.v2Meta, tt.v2)
+
+			expr := NewNumericExpressionFieldValue(field1, tt.operator, field2)
+			result, err := executeAndGetValueForNumericTest(t, expr, ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNumericExpressionField_IntDecimalPromotion_OutputType(t *testing.T) {
 	ctx := context.Background()
 	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
 	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
@@ -121,9 +189,73 @@ func TestNumericExpressionField_IncompatibleTypes(t *testing.T) {
 	field2 := NewConstantFieldValue(decMeta, 5.5)
 
 	expr := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorAdd, field2)
+	exprMeta, err := executeAndGetMetaForNumericTest(t, expr, ctx)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeDecimal, exprMeta.DataType)
+}
+
+func TestNumericExpressionField_IntDecimalModulo_Error(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	field1 := NewConstantFieldValue(intMeta, int64(10))
+	field2 := NewConstantFieldValue(decMeta, 3.0)
+
+	expr := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorMod, field2)
 	_, _, err := expr.Execute(ctx, []tsquery.FieldMeta{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "incompatible datatypes")
+	require.Contains(t, err.Error(), "mod operator is only supported for integer fields")
+}
+
+func TestNumericExpressionField_DecimalIntModulo_Error(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	field1 := NewConstantFieldValue(decMeta, 10.0)
+	field2 := NewConstantFieldValue(intMeta, int64(3))
+
+	expr := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorMod, field2)
+	_, _, err := expr.Execute(ctx, []tsquery.FieldMeta{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mod operator is only supported for integer fields")
+}
+
+func TestNumericExpressionField_IntDecimalPromotion_Chained(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	// (int + decimal) * int → decimal
+	field1 := NewConstantFieldValue(intMeta, int64(10))
+	field2 := NewConstantFieldValue(decMeta, 5.5)
+	field3 := NewConstantFieldValue(intMeta, int64(2))
+
+	expr1 := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorAdd, field2)
+	expr2 := NewNumericExpressionFieldValue(expr1, tsquery.BinaryNumericOperatorMul, field3)
+
+	result, err := executeAndGetValueForNumericTest(t, expr2, ctx)
+	require.NoError(t, err)
+	require.Equal(t, float64(31.0), result)
+
+	exprMeta, err := executeAndGetMetaForNumericTest(t, expr2, ctx)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.DataTypeDecimal, exprMeta.DataType)
+}
+
+func TestNumericExpressionField_IntDecimalPromotion_OptionalNil(t *testing.T) {
+	ctx := context.Background()
+	intMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeInteger, Required: false}
+	decMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: false}
+
+	field1 := NewConstantFieldValue(intMeta, nil)
+	field2 := NewConstantFieldValue(decMeta, 5.5)
+
+	expr := NewNumericExpressionFieldValue(field1, tsquery.BinaryNumericOperatorAdd, field2)
+	result, err := executeAndGetValueForNumericTest(t, expr, ctx)
+	require.NoError(t, err)
+	require.Nil(t, result)
 }
 
 func TestNumericExpressionField_NonNumericTypes(t *testing.T) {


### PR DESCRIPTION
…ions

When a numeric expression combines integer and decimal operands, automatically promote the integer to decimal instead of returning a type mismatch error. This applies across all three evaluation layers (datasource, report, aggregation) and to both arithmetic expressions and condition comparisons.

Also fixes a bug where aggregation Evaluate returned the wrong DataType on nil propagation through mixed-type expressions (returned dt1 instead of promoted type).