### PR TITLE
Add optional samplePeriod to FieldMeta for delta metric alignment

### DIFF
--- a/docs/metric-kind-plan.md
+++ b/docs/metric-kind-plan.md
@@ -154,6 +154,20 @@ There is no transition flag or "unspecified" escape hatch. If a metric reaches D
 2. Tag cumulative/delta metrics with `metricKind` in datasources -- nothing breaks
 3. Upgrade to Phase 2 release -- any untagged metrics hitting DeltaFilter will error with a clear message
 
+### 9. Optional samplePeriod on FieldMeta
+
+An optional `samplePeriod` (`*time.Duration`) on `FieldMeta` declares the expected reporting interval for a metric (e.g., "this delta reports every 5m"). This is orthogonal to MetricKind -- useful for all kinds, not just delta -- but particularly valuable for delta metrics where missing samples cause silent undercounting during alignment.
+
+**How it works:**
+- Datasources set `samplePeriod` via `WithSamplePeriod(5 * time.Minute)` in Go or `"samplePeriod": "5m"` in JSON
+- All field values and filters propagate it (same pattern as MetricKind)
+- RateFilter clears it (rate output has no meaningful sample period)
+- Overridable via `OverrideFieldMetadataFilter` and `AddFieldMeta.overrideSamplePeriod`
+- Phase 1: plumbing only, no behavior changes
+- Phase 2: AlignerFilter uses `samplePeriod` + `MetricKind=Delta` for gap detection and proration
+
+**Industry context:** OpenTelemetry carries explicit start/end timestamps per delta point. Prometheus extrapolates to cover gaps. Google Cloud Monitoring interpolates missing periods. Our approach is lighter -- metadata on the field rather than per-point timestamps -- but enables the same downstream decisions.
+
 ---
 
 ## Phase 1: Types, Plumbing, Propagation

--- a/utils/timeseries/tsquery/aggregation/expression_aggregation.go
+++ b/utils/timeseries/tsquery/aggregation/expression_aggregation.go
@@ -58,6 +58,7 @@ func (e *ExpressionAggregation) Execute(ctx context.Context, from, to time.Time)
 			metricKind = field.AddFieldMeta.OverrideMetricKind
 		}
 
+		// samplePeriod not propagated — aggregation produces a terminal scalar, not a time series
 		meta, err := tsquery.NewFieldMetaFull(urn, resolvedType, metricKind, true, field.AddFieldMeta.OverrideUnit, field.AddFieldMeta.CustomMeta)
 		if err != nil {
 			return Result{}, fmt.Errorf("expression aggregation field %d: failed to build metadata: %w", i, err)

--- a/utils/timeseries/tsquery/aggregation/from_datasource_aggregation.go
+++ b/utils/timeseries/tsquery/aggregation/from_datasource_aggregation.go
@@ -141,6 +141,7 @@ func buildFieldMeta(field AggregationFieldDef, sourceMeta tsquery.FieldMeta, res
 		metricKind = field.AddFieldMeta.OverrideMetricKind
 	}
 
+	// samplePeriod not propagated — aggregation produces a terminal scalar, not a time series
 	return tsquery.NewFieldMetaFull(urn, resultDataType, metricKind, sourceMeta.Required(), unit, customMeta)
 }
 

--- a/utils/timeseries/tsquery/aggregation/from_report_aggregation.go
+++ b/utils/timeseries/tsquery/aggregation/from_report_aggregation.go
@@ -168,6 +168,7 @@ func buildReportFieldMeta(field ReportAggregationFieldDef, sourceMeta tsquery.Fi
 		metricKind = field.AddFieldMeta.OverrideMetricKind
 	}
 
+	// samplePeriod not propagated — aggregation produces a terminal scalar, not a time series
 	return tsquery.NewFieldMetaFull(urn, resultDataType, metricKind, sourceMeta.Required(), unit, customMeta)
 }
 

--- a/utils/timeseries/tsquery/datasource/aligner_filter.go
+++ b/utils/timeseries/tsquery/datasource/aligner_filter.go
@@ -101,6 +101,10 @@ func (af AlignerFilter) Filter(_ context.Context, result Result) (Result, error)
 			if err != nil {
 				return util.DefaultValue[Result](), fmt.Errorf("failed to create new field meta for bucket reduction: %w", err)
 			}
+			if sp := result.meta.SamplePeriod(); sp != nil {
+				*newMeta = newMeta.WithSamplePeriod(*sp)
+			}
+			// TODO Phase 2: derive samplePeriod from alignment period when bucket reduction changes the effective cadence
 			resultMeta = *newMeta
 		}
 	}

--- a/utils/timeseries/tsquery/datasource/cast_field_value.go
+++ b/utils/timeseries/tsquery/datasource/cast_field_value.go
@@ -43,9 +43,10 @@ func (cf CastFieldValue) Execute(ctx context.Context, fieldMeta tsquery.FieldMet
 
 	// Create field value metadata for the cast result
 	fieldValueMeta := tsquery.ValueMeta{
-		DataType:   cf.targetType,
-		MetricKind: sourceMeta.MetricKind,
-		Unit:       sourceMeta.Unit,
+		DataType:     cf.targetType,
+		MetricKind:   sourceMeta.MetricKind,
+		SamplePeriod: sourceMeta.SamplePeriod,
+		Unit:         sourceMeta.Unit,
 		Required:   sourceMeta.Required,
 		CustomMeta: sourceMeta.CustomMeta,
 	}

--- a/utils/timeseries/tsquery/datasource/datasource_filter.go
+++ b/utils/timeseries/tsquery/datasource/datasource_filter.go
@@ -26,6 +26,17 @@ func PrepareFieldValue(
 	if meta.OverrideMetricKind != "" {
 		metricKind = meta.OverrideMetricKind
 	}
+	var samplePeriod *time.Duration
+	if valueMeta.SamplePeriod != nil {
+		samplePeriod = valueMeta.SamplePeriod
+	}
+	if meta.OverrideSamplePeriod != "" {
+		sp, err := time.ParseDuration(meta.OverrideSamplePeriod)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid OverrideSamplePeriod for field %s: %w", meta.Urn, err)
+		}
+		samplePeriod = &sp
+	}
 	fm, err := tsquery.NewFieldMetaFull(
 		meta.Urn,
 		valueMeta.DataType,
@@ -36,6 +47,9 @@ func PrepareFieldValue(
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed creating field meta for %s: %w", meta.Urn, err)
+	}
+	if samplePeriod != nil {
+		*fm = fm.WithSamplePeriod(*samplePeriod)
 	}
 	return fm, valueSupplier, nil
 

--- a/utils/timeseries/tsquery/datasource/metric_kind_propagation_test.go
+++ b/utils/timeseries/tsquery/datasource/metric_kind_propagation_test.go
@@ -133,7 +133,7 @@ func TestOverrideFieldMetadataFilter_OverrideKind(t *testing.T) {
 	result := Result{meta: meta, data: simpleStream(1, 2, 3)}
 
 	cumKind := tsquery.MetricKindCumulative
-	filter := NewOverrideFieldMetadataFilter(nil, nil, &cumKind, nil)
+	filter := NewOverrideFieldMetadataFilter(nil, nil, &cumKind, nil, nil)
 	filtered, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 	require.Equal(t, tsquery.MetricKindCumulative, filtered.Meta().MetricKind())
@@ -150,7 +150,7 @@ func TestOverrideFieldMetadataFilter_PreservesKind_WhenNil(t *testing.T) {
 
 	// Override URN but not kind
 	newUrn := "renamed"
-	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil, nil)
 	filtered, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 	require.Equal(t, tsquery.MetricKindCumulative, filtered.Meta().MetricKind())
@@ -316,4 +316,135 @@ func TestValueMetaPropagation_NestedExpressions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tsquery.DataTypeDecimal, valueMeta.DataType)
 	require.Equal(t, tsquery.MetricKindCumulative, valueMeta.MetricKind)
+}
+
+// --- SamplePeriod propagation tests ---
+
+func TestDeltaFilter_PreservesSamplePeriod(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	meta := cumulativeDecimalMeta(t).WithSamplePeriod(fiveMin)
+
+	result := Result{meta: meta, data: simpleStream(100, 110, 125)}
+
+	df := NewDeltaFilter(false, 0, false, nil)
+	filtered, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+	require.NotNil(t, filtered.Meta().SamplePeriod())
+	require.Equal(t, fiveMin, *filtered.Meta().SamplePeriod())
+	require.Equal(t, tsquery.MetricKindDelta, filtered.Meta().MetricKind())
+}
+
+func TestRateFilter_ClearsSamplePeriod(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	meta := cumulativeDecimalMeta(t).WithSamplePeriod(fiveMin)
+
+	result := Result{meta: meta, data: simpleStream(100, 160)}
+
+	rf := NewRateFilter("kW", 1, false, 0, false, nil)
+	filtered, err := rf.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Nil(t, filtered.Meta().SamplePeriod(), "rate output should have no sample period")
+	require.Equal(t, tsquery.MetricKindRate, filtered.Meta().MetricKind())
+}
+
+func TestAlignerFilter_PreservesSamplePeriod(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	fm, err := tsquery.NewFieldMetaFull("energy", tsquery.DataTypeDecimal, tsquery.MetricKindDelta, true, "kWh", nil)
+	require.NoError(t, err)
+	*fm = fm.WithSamplePeriod(fiveMin)
+
+	result := Result{meta: *fm, data: simpleStream(10, 15, 20)}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(10*time.Minute, time.UTC))
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+	require.NotNil(t, filtered.Meta().SamplePeriod())
+	require.Equal(t, fiveMin, *filtered.Meta().SamplePeriod())
+}
+
+func TestCastFieldValue_PropagatesSamplePeriod(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	sourceMeta := tsquery.ValueMeta{
+		DataType:     tsquery.DataTypeInteger,
+		MetricKind:   tsquery.MetricKindDelta,
+		SamplePeriod: &fiveMin,
+		Required:     true,
+	}
+	source := NewConstantFieldValue(sourceMeta, int64(100))
+	cast := NewCastFieldValue(source, tsquery.DataTypeDecimal)
+
+	valueMeta, _, err := cast.Execute(ctx, dummyFieldMeta())
+	require.NoError(t, err)
+	require.NotNil(t, valueMeta.SamplePeriod)
+	require.Equal(t, fiveMin, *valueMeta.SamplePeriod)
+}
+
+func TestNilSamplePeriod_NotPropagatedWhenUnset(t *testing.T) {
+	ctx := context.Background()
+	// Source without samplePeriod — should stay nil through cast
+	sourceMeta := tsquery.ValueMeta{
+		DataType: tsquery.DataTypeDecimal,
+		Required: true,
+	}
+	source := NewConstantFieldValue(sourceMeta, 42.0)
+	cast := NewCastFieldValue(source, tsquery.DataTypeDecimal)
+
+	valueMeta, _, err := cast.Execute(ctx, dummyFieldMeta())
+	require.NoError(t, err)
+	require.Nil(t, valueMeta.SamplePeriod)
+}
+
+// --- SamplePeriod override tests ---
+
+func TestOverrideFieldMetadataFilter_OverrideSamplePeriod(t *testing.T) {
+	ctx := context.Background()
+	meta := gaugeDecimalMeta(t)
+	result := Result{meta: meta, data: simpleStream(1, 2, 3)}
+
+	tenMin := 10 * time.Minute
+	filter := NewOverrideFieldMetadataFilter(nil, nil, nil, &tenMin, nil)
+	filtered, err := filter.Filter(ctx, result)
+	require.NoError(t, err)
+	require.NotNil(t, filtered.Meta().SamplePeriod())
+	require.Equal(t, tenMin, *filtered.Meta().SamplePeriod())
+}
+
+func TestOverrideFieldMetadataFilter_PreservesSamplePeriod_WhenNil(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	meta := deltaDecimalMeta(t).WithSamplePeriod(fiveMin)
+	result := Result{meta: meta, data: simpleStream(1, 2, 3)}
+
+	// Override URN only — samplePeriod should be preserved
+	newUrn := "renamed"
+	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil, nil)
+	filtered, err := filter.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Equal(t, "renamed", filtered.Meta().Urn())
+	require.NotNil(t, filtered.Meta().SamplePeriod())
+	require.Equal(t, fiveMin, *filtered.Meta().SamplePeriod())
+}
+
+func TestFieldValueFilter_OverrideSamplePeriod(t *testing.T) {
+	ctx := context.Background()
+	meta := deltaDecimalMeta(t)
+	result := Result{meta: meta, data: simpleStream(1, 2, 3)}
+
+	// FieldValueFilter with AddFieldMeta that overrides samplePeriod
+	ref := NewRefFieldValue()
+	addMeta := tsquery.AddFieldMeta{
+		Urn:                  "energy_ref",
+		OverrideSamplePeriod: "15m",
+	}
+	fvf := NewFieldValueFilter(ref, addMeta)
+
+	filtered, err := fvf.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Equal(t, "energy_ref", filtered.Meta().Urn())
+	require.NotNil(t, filtered.Meta().SamplePeriod())
+	require.Equal(t, 15*time.Minute, *filtered.Meta().SamplePeriod())
 }

--- a/utils/timeseries/tsquery/datasource/numeric_expression_field_value.go
+++ b/utils/timeseries/tsquery/datasource/numeric_expression_field_value.go
@@ -104,9 +104,10 @@ func (nef NumericExpressionFieldValue) Execute(ctx context.Context, fieldMeta ts
 
 	// Merge CustomMeta from both operands, op1 takes precedence on conflicts
 	fvm := tsquery.ValueMeta{
-		DataType:   promotedType,
-		MetricKind: op1Meta.MetricKind,
-		Unit:       updatedUnit,
+		DataType:     promotedType,
+		MetricKind:   op1Meta.MetricKind,
+		SamplePeriod: op1Meta.SamplePeriod,
+		Unit:         updatedUnit,
 		Required:   op1Meta.Required && op2Meta.Required,
 		CustomMeta: tsquery.MergeCustomMeta(op2Meta.CustomMeta, op1Meta.CustomMeta),
 	}

--- a/utils/timeseries/tsquery/datasource/nvl_field_value.go
+++ b/utils/timeseries/tsquery/datasource/nvl_field_value.go
@@ -56,9 +56,10 @@ func (nf NvlFieldValue) Execute(ctx context.Context, fieldMeta tsquery.FieldMeta
 	// Create field metadata - NVL field is always required since we have a fallback
 	// Propagate CustomMeta from source only (not from alt)
 	fvm := tsquery.ValueMeta{
-		DataType:   sourceType,
-		MetricKind: sourceMeta.MetricKind,
-		Unit:       sourceMeta.Unit,
+		DataType:     sourceType,
+		MetricKind:   sourceMeta.MetricKind,
+		SamplePeriod: sourceMeta.SamplePeriod,
+		Unit:         sourceMeta.Unit,
 		Required:   true,
 		CustomMeta: sourceMeta.CustomMeta,
 	}

--- a/utils/timeseries/tsquery/datasource/override_field_metadata_filter.go
+++ b/utils/timeseries/tsquery/datasource/override_field_metadata_filter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
+	"time"
 )
 
 var _ Filter = OverrideFieldMetadataFilter{}
@@ -12,10 +13,11 @@ var _ Filter = OverrideFieldMetadataFilter{}
 // of a datasource result. It can selectively modify URN, Unit, and CustomMeta
 // while preserving DataType and Required status (which are immutable).
 type OverrideFieldMetadataFilter struct {
-	optUpdatedUrn        *string
-	optUpdatedUnit       *string
-	optUpdatedMetricKind *tsquery.MetricKind
-	optUpdatedCustomMeta map[string]any
+	optUpdatedUrn          *string
+	optUpdatedUnit         *string
+	optUpdatedMetricKind   *tsquery.MetricKind
+	optUpdatedSamplePeriod *time.Duration
+	optUpdatedCustomMeta   map[string]any
 }
 
 // NewOverrideFieldMetadataFilter creates a new filter that overrides field metadata.
@@ -23,18 +25,21 @@ type OverrideFieldMetadataFilter struct {
 // - optUpdatedUrn: overrides the field's URN
 // - optUpdatedUnit: overrides the field's unit
 // - optUpdatedMetricKind: overrides the field's metric kind
+// - optUpdatedSamplePeriod: overrides the field's sample period
 // - optUpdatedCustomMeta: replaces the field's custom metadata entirely
 func NewOverrideFieldMetadataFilter(
 	optUpdatedUrn *string,
 	optUpdatedUnit *string,
 	optUpdatedMetricKind *tsquery.MetricKind,
+	optUpdatedSamplePeriod *time.Duration,
 	optUpdatedCustomMeta map[string]any,
 ) OverrideFieldMetadataFilter {
 	return OverrideFieldMetadataFilter{
-		optUpdatedUrn:        optUpdatedUrn,
-		optUpdatedUnit:       optUpdatedUnit,
-		optUpdatedMetricKind: optUpdatedMetricKind,
-		optUpdatedCustomMeta: optUpdatedCustomMeta,
+		optUpdatedUrn:          optUpdatedUrn,
+		optUpdatedUnit:         optUpdatedUnit,
+		optUpdatedMetricKind:   optUpdatedMetricKind,
+		optUpdatedSamplePeriod: optUpdatedSamplePeriod,
+		optUpdatedCustomMeta:   optUpdatedCustomMeta,
 	}
 }
 
@@ -58,6 +63,11 @@ func (ofm OverrideFieldMetadataFilter) Filter(ctx context.Context, result Result
 		finalMetricKind = *ofm.optUpdatedMetricKind
 	}
 
+	finalSamplePeriod := fieldMeta.SamplePeriod()
+	if ofm.optUpdatedSamplePeriod != nil {
+		finalSamplePeriod = ofm.optUpdatedSamplePeriod
+	}
+
 	finalCustomMeta := fieldMeta.CustomMeta()
 	if ofm.optUpdatedCustomMeta != nil {
 		// Replace custom metadata entirely (not merge)
@@ -76,6 +86,9 @@ func (ofm OverrideFieldMetadataFilter) Filter(ctx context.Context, result Result
 	)
 	if err != nil {
 		return Result{}, fmt.Errorf("failed to create updated field metadata: %w", err)
+	}
+	if finalSamplePeriod != nil {
+		*updatedFieldMeta = updatedFieldMeta.WithSamplePeriod(*finalSamplePeriod)
 	}
 
 	// Return a new result with updated metadata but same data stream

--- a/utils/timeseries/tsquery/datasource/override_field_metadata_filter_test.go
+++ b/utils/timeseries/tsquery/datasource/override_field_metadata_filter_test.go
@@ -27,7 +27,7 @@ func TestOverrideFieldMetadataFilter_OverrideUrn(t *testing.T) {
 	require.NoError(t, err)
 
 	// Apply filter to override URN
-	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil, nil)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute
@@ -63,7 +63,7 @@ func TestOverrideFieldMetadataFilter_OverrideUnit(t *testing.T) {
 
 	// Apply filter to override unit
 	newUnit := "fahrenheit"
-	filter := NewOverrideFieldMetadataFilter(nil, &newUnit, nil, nil)
+	filter := NewOverrideFieldMetadataFilter(nil, &newUnit, nil, nil, nil)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute
@@ -113,7 +113,7 @@ func TestOverrideFieldMetadataFilter_OverrideCustomMeta(t *testing.T) {
 		"version":     "v2",
 		"environment": "production",
 	}
-	filter := NewOverrideFieldMetadataFilter(nil, nil, nil, newCustomMeta)
+	filter := NewOverrideFieldMetadataFilter(nil, nil, nil, nil, newCustomMeta)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute
@@ -160,7 +160,7 @@ func TestOverrideFieldMetadataFilter_OverrideMultipleFields(t *testing.T) {
 	newUnit := "new_unit"
 	newCustomMeta := map[string]any{"key": "new"}
 
-	filter := NewOverrideFieldMetadataFilter(&newUrn, &newUnit, nil, newCustomMeta)
+	filter := NewOverrideFieldMetadataFilter(&newUrn, &newUnit, nil, nil, newCustomMeta)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute
@@ -195,7 +195,7 @@ func TestOverrideFieldMetadataFilter_NoOverrides(t *testing.T) {
 	require.NoError(t, err)
 
 	// Apply filter with no overrides (all nil)
-	filter := NewOverrideFieldMetadataFilter(nil, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter(nil, nil, nil, nil, nil)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute
@@ -228,7 +228,7 @@ func TestOverrideFieldMetadataFilter_DataTypeImmutable(t *testing.T) {
 
 	// Apply filter (DataType cannot be changed via this filter)
 	newUrn := "renamed"
-	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil, nil)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute
@@ -255,7 +255,7 @@ func TestOverrideFieldMetadataFilter_RequiredImmutable(t *testing.T) {
 
 	// Apply filter (Required cannot be changed via this filter)
 	newUrn := "renamed"
-	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter(&newUrn, nil, nil, nil, nil)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute
@@ -282,7 +282,7 @@ func TestOverrideFieldMetadataFilter_EmptyUrn(t *testing.T) {
 
 	// Try to override with empty URN (should fail)
 	emptyUrn := ""
-	filter := NewOverrideFieldMetadataFilter(&emptyUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter(&emptyUrn, nil, nil, nil, nil)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute and expect error
@@ -321,7 +321,7 @@ func TestOverrideFieldMetadataFilter_CustomMetaReplacement(t *testing.T) {
 	newCustomMeta := map[string]any{
 		"version": "v2",
 	}
-	filter := NewOverrideFieldMetadataFilter(nil, nil, nil, newCustomMeta)
+	filter := NewOverrideFieldMetadataFilter(nil, nil, nil, nil, newCustomMeta)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute
@@ -359,7 +359,7 @@ func TestOverrideFieldMetadataFilter_PreservesStreamData(t *testing.T) {
 	newUrn := "renamed"
 	newUnit := "items"
 	newCustomMeta := map[string]any{"version": "v2"}
-	filter := NewOverrideFieldMetadataFilter(&newUrn, &newUnit, nil, newCustomMeta)
+	filter := NewOverrideFieldMetadataFilter(&newUrn, &newUnit, nil, nil, newCustomMeta)
 	filteredDS := NewFilteredDataSource(ds, filter)
 
 	// Execute

--- a/utils/timeseries/tsquery/datasource/rate_filter.go
+++ b/utils/timeseries/tsquery/datasource/rate_filter.go
@@ -47,6 +47,7 @@ func (rf RateFilter) Filter(_ context.Context, result Result) (Result, error) {
 		)
 	}
 
+	// samplePeriod intentionally not set — a computed rate has no meaningful sample period
 	newMeta, err := tsquery.NewFieldMetaFull(
 		result.meta.Urn(),
 		tsquery.DataTypeDecimal,

--- a/utils/timeseries/tsquery/datasource/reduction_datasource.go
+++ b/utils/timeseries/tsquery/datasource/reduction_datasource.go
@@ -171,6 +171,16 @@ func (r ReductionDatasource) Execute(ctx context.Context, from time.Time, to tim
 		metricKind = r.addFieldMeta.OverrideMetricKind
 	}
 
+	// Determine sample period: use override if provided, otherwise from the first datasource
+	samplePeriod := datasourceMetas[0].SamplePeriod()
+	if r.addFieldMeta.OverrideSamplePeriod != "" {
+		sp, err := time.ParseDuration(r.addFieldMeta.OverrideSamplePeriod)
+		if err != nil {
+			return util.DefaultValue[Result](), fmt.Errorf("invalid OverrideSamplePeriod for reduction datasource %s: %w", urn, err)
+		}
+		samplePeriod = &sp
+	}
+
 	// Create result field metadata
 	resultFieldMeta, err := tsquery.NewFieldMetaFull(
 		urn,
@@ -182,6 +192,9 @@ func (r ReductionDatasource) Execute(ctx context.Context, from time.Time, to tim
 	)
 	if err != nil {
 		return util.DefaultValue[Result](), fmt.Errorf("failed to create result field metadata: %w", err)
+	}
+	if samplePeriod != nil {
+		*resultFieldMeta = resultFieldMeta.WithSamplePeriod(*samplePeriod)
 	}
 
 	// Pre-compute the reduction function based on type and data type
@@ -240,6 +253,16 @@ func (r ReductionDatasource) executeEmptyDatasourceFallback(ctx context.Context,
 		emptyMetricKind = r.addFieldMeta.OverrideMetricKind
 	}
 
+	// Determine sample period for empty fallback
+	emptySamplePeriod := valueMeta.SamplePeriod
+	if r.addFieldMeta.OverrideSamplePeriod != "" {
+		sp, err := time.ParseDuration(r.addFieldMeta.OverrideSamplePeriod)
+		if err != nil {
+			return util.DefaultValue[Result](), fmt.Errorf("invalid OverrideSamplePeriod for empty reduction datasource %s: %w", r.addFieldMeta.Urn, err)
+		}
+		emptySamplePeriod = &sp
+	}
+
 	// Create result field metadata from the emptyDatasourceValue's metadata
 	resultFieldMeta, err := tsquery.NewFieldMetaFull(
 		r.addFieldMeta.Urn,
@@ -251,6 +274,9 @@ func (r ReductionDatasource) executeEmptyDatasourceFallback(ctx context.Context,
 	)
 	if err != nil {
 		return util.DefaultValue[Result](), fmt.Errorf("failed to create result field metadata for empty datasource: %w", err)
+	}
+	if emptySamplePeriod != nil {
+		*resultFieldMeta = resultFieldMeta.WithSamplePeriod(*emptySamplePeriod)
 	}
 
 	// Generate aligned timestamps stream and map to TsRecords with the fallback value

--- a/utils/timeseries/tsquery/datasource/ref_field_value.go
+++ b/utils/timeseries/tsquery/datasource/ref_field_value.go
@@ -22,9 +22,10 @@ func (rf RefFieldValue) Execute(ctx context.Context, fieldMeta tsquery.FieldMeta
 	}
 
 	return tsquery.ValueMeta{
-		DataType:   fieldMeta.DataType(),
-		MetricKind: fieldMeta.MetricKind(),
-		Unit:       fieldMeta.Unit(),
+		DataType:     fieldMeta.DataType(),
+		MetricKind:   fieldMeta.MetricKind(),
+		SamplePeriod: fieldMeta.SamplePeriod(),
+		Unit:         fieldMeta.Unit(),
 		Required:   fieldMeta.Required(),
 		CustomMeta: fieldMeta.CustomMeta(),
 	}, valueSupplier, nil

--- a/utils/timeseries/tsquery/datasource/selector_field_value.go
+++ b/utils/timeseries/tsquery/datasource/selector_field_value.go
@@ -90,9 +90,10 @@ func (cf SelectorFieldValue) Execute(ctx context.Context, fieldMeta tsquery.Fiel
 
 	// Create field metadata
 	fvm := tsquery.ValueMeta{
-		DataType:   trueType,
-		MetricKind: trueMeta.MetricKind,
-		Unit:       trueMeta.Unit,
+		DataType:     trueType,
+		MetricKind:   trueMeta.MetricKind,
+		SamplePeriod: trueMeta.SamplePeriod,
+		Unit:         trueMeta.Unit,
 		Required:   trueMeta.Required,
 	}
 

--- a/utils/timeseries/tsquery/datasource/unary_numeric_operator_field_value.go
+++ b/utils/timeseries/tsquery/datasource/unary_numeric_operator_field_value.go
@@ -45,9 +45,10 @@ func (ufv UnaryNumericOperatorFieldValue) Execute(ctx context.Context, fieldMeta
 	}
 
 	fvm := tsquery.ValueMeta{
-		DataType:   dt,
-		MetricKind: operandMeta.MetricKind,
-		Unit:       operandMeta.Unit,
+		DataType:     dt,
+		MetricKind:   operandMeta.MetricKind,
+		SamplePeriod: operandMeta.SamplePeriod,
+		Unit:         operandMeta.Unit,
 		Required:   operandMeta.Required,
 		CustomMeta: operandMeta.CustomMeta,
 	}

--- a/utils/timeseries/tsquery/metric_kind_test.go
+++ b/utils/timeseries/tsquery/metric_kind_test.go
@@ -2,6 +2,7 @@ package tsquery
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -83,4 +84,40 @@ func TestNewFieldMetaWithCustomData_BackwardCompat(t *testing.T) {
 	fm, err := NewFieldMetaWithCustomData("test", DataTypeDecimal, true, "kWh", nil)
 	require.NoError(t, err)
 	require.Equal(t, MetricKindGauge, fm.MetricKind())
+}
+
+// --- SamplePeriod tests ---
+
+func TestFieldMeta_SamplePeriod_DefaultNil(t *testing.T) {
+	fm, err := NewFieldMeta("test", DataTypeDecimal, true)
+	require.NoError(t, err)
+	require.Nil(t, fm.SamplePeriod())
+}
+
+func TestFieldMeta_WithSamplePeriod(t *testing.T) {
+	fm, err := NewFieldMeta("test", DataTypeDecimal, true)
+	require.NoError(t, err)
+
+	fiveMin := 5 * time.Minute
+	withSP := fm.WithSamplePeriod(fiveMin)
+
+	// Original unchanged
+	require.Nil(t, fm.SamplePeriod())
+
+	// Copy has the value
+	require.NotNil(t, withSP.SamplePeriod())
+	require.Equal(t, fiveMin, *withSP.SamplePeriod())
+}
+
+func TestFieldMeta_WithSamplePeriod_ChainedWithMetricKind(t *testing.T) {
+	fm, err := NewFieldMetaFull("energy", DataTypeDecimal, MetricKindDelta, true, "kWh", nil)
+	require.NoError(t, err)
+
+	fiveMin := 5 * time.Minute
+	fm2 := fm.WithSamplePeriod(fiveMin)
+
+	require.Equal(t, MetricKindDelta, fm2.MetricKind())
+	require.NotNil(t, fm2.SamplePeriod())
+	require.Equal(t, fiveMin, *fm2.SamplePeriod())
+	require.Equal(t, "kWh", fm2.Unit())
 }

--- a/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_datasource.go
+++ b/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_datasource.go
@@ -4,6 +4,8 @@ package queryopenapi
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/shpandrak/shpanstream/stream"
 	"github.com/shpandrak/shpanstream/utils/timeseries"
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
@@ -46,6 +48,13 @@ func parseStaticDatasource(ds ApiStaticQueryDatasource) (datasource.DataSource, 
 	)
 	if err != nil {
 		return nil, badInputErrorWrap(ds.FieldMeta, err, "failed to create field metadata for static datasource")
+	}
+	if ds.FieldMeta.SamplePeriod != "" {
+		sp, err := time.ParseDuration(ds.FieldMeta.SamplePeriod)
+		if err != nil {
+			return nil, badInputErrorWrap(ds.FieldMeta, err, "invalid samplePeriod")
+		}
+		*fieldMeta = fieldMeta.WithSamplePeriod(sp)
 	}
 
 	// Convert API data to timeseries records (single value per record)

--- a/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_filter.go
+++ b/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_filter.go
@@ -69,10 +69,20 @@ func parseOverrideFieldMetadataFilter(overrideFilter ApiOverrideFieldMetadataFil
 		optUpdatedMetricKind = &overrideFilter.UpdatedMetricKind
 	}
 
+	var optUpdatedSamplePeriod *time.Duration
+	if overrideFilter.UpdatedSamplePeriod != "" {
+		sp, err := time.ParseDuration(overrideFilter.UpdatedSamplePeriod)
+		if err != nil {
+			return nil, badInputErrorWrap(overrideFilter, err, "invalid updatedSamplePeriod")
+		}
+		optUpdatedSamplePeriod = &sp
+	}
+
 	return datasource.NewOverrideFieldMetadataFilter(
 		optUpdatedUrn,
 		optUpdatedUnit,
 		optUpdatedMetricKind,
+		optUpdatedSamplePeriod,
 		overrideFilter.UpdatedCustomMeta,
 	), nil
 }
@@ -217,10 +227,11 @@ func parseCustomAlignmentPeriod(period ApiCustomAlignmentPeriod) (timeseries.Ali
 
 func ParseAddFieldMeta(apiMeta ApiAddFieldMeta) tsquery.AddFieldMeta {
 	return tsquery.AddFieldMeta{
-		Urn:                apiMeta.Uri,
-		CustomMeta:         apiMeta.CustomMetadata,
-		OverrideUnit:       apiMeta.OverrideUnit,
-		OverrideMetricKind: apiMeta.OverrideMetricKind,
+		Urn:                  apiMeta.Uri,
+		CustomMeta:           apiMeta.CustomMetadata,
+		OverrideUnit:         apiMeta.OverrideUnit,
+		OverrideMetricKind:   apiMeta.OverrideMetricKind,
+		OverrideSamplePeriod: apiMeta.OverrideSamplePeriod,
 	}
 }
 

--- a/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_report_datasource.go
+++ b/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_report_datasource.go
@@ -4,6 +4,8 @@ package queryopenapi
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/shpandrak/shpanstream/stream"
 	"github.com/shpandrak/shpanstream/utils/timeseries"
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
@@ -48,6 +50,13 @@ func parseStaticReportDatasource(ds ApiStaticReportDatasource) (report.DataSourc
 		)
 		if err != nil {
 			return nil, badInputErrorWrap(fm, err, "failed to create field metadata %d for static report datasource", i)
+		}
+		if fm.SamplePeriod != "" {
+			sp, err := time.ParseDuration(fm.SamplePeriod)
+			if err != nil {
+				return nil, badInputErrorWrap(fm, err, "invalid samplePeriod for field %d", i)
+			}
+			*meta = meta.WithSamplePeriod(sp)
 		}
 		fieldsMeta[i] = *meta
 	}

--- a/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/tsquery-swagger.yaml
+++ b/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/tsquery-swagger.yaml
@@ -288,6 +288,10 @@ components:
           x-go-type-skip-optional-pointer: true
         overrideMetricKind:
           $ref: '#/components/schemas/ApiMetricKind'
+        overrideSamplePeriod:
+          type: string
+          description: Override the sample period for the output field (Go duration string, e.g. "5m", "1h").
+          x-go-type-skip-optional-pointer: true
         customMetadata:
           x-go-type-skip-optional-pointer: true
           type: object
@@ -341,6 +345,10 @@ components:
           x-go-type-skip-optional-pointer: true
         updatedMetricKind:
           $ref: '#/components/schemas/ApiMetricKind'
+        updatedSamplePeriod:
+          type: string
+          description: Override the sample period (Go duration string, e.g. "5m", "1h").
+          x-go-type-skip-optional-pointer: true
         updatedCustomMeta:
           type: object
           additionalProperties: true
@@ -846,6 +854,10 @@ components:
           minLength: 1
         metricKind:
           $ref: '#/components/schemas/ApiMetricKind'
+        samplePeriod:
+          type: string
+          description: Expected reporting interval as a Go duration string (e.g., "5m", "1h"). For delta metrics, this declares the wall-clock window each sample covers.
+          x-go-type-skip-optional-pointer: true
         customMetadata:
           type: object
           additionalProperties: true

--- a/utils/timeseries/tsquery/queryopenapi/codegen/testdata/custom_parser.go
+++ b/utils/timeseries/tsquery/queryopenapi/codegen/testdata/custom_parser.go
@@ -7,6 +7,7 @@ import (
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery/datasource"
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery/report"
+	"time"
 )
 
 // CustomPluginParser implements PluginApiParser to handle custom datasource types
@@ -68,6 +69,13 @@ func parsePostgresDatasource(ds ApiPostgresQueryDatasource) (datasource.DataSour
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create field metadata for postgres datasource: %w", err)
+	}
+	if ds.FieldMeta.SamplePeriod != "" {
+		sp, err := time.ParseDuration(ds.FieldMeta.SamplePeriod)
+		if err != nil {
+			return nil, fmt.Errorf("invalid samplePeriod for postgres datasource: %w", err)
+		}
+		*fieldMeta = fieldMeta.WithSamplePeriod(sp)
 	}
 
 	// In a real implementation, this would:

--- a/utils/timeseries/tsquery/queryopenapi/codegen/testdata/extended-swagger.yaml
+++ b/utils/timeseries/tsquery/queryopenapi/codegen/testdata/extended-swagger.yaml
@@ -313,6 +313,10 @@ components:
                     x-go-type-skip-optional-pointer: true
                 overrideMetricKind:
                     $ref: '#/components/schemas/ApiMetricKind'
+                overrideSamplePeriod:
+                    type: string
+                    description: Override the sample period for the output field (Go duration string, e.g. "5m", "1h").
+                    x-go-type-skip-optional-pointer: true
                 customMetadata:
                     x-go-type-skip-optional-pointer: true
                     type: object
@@ -366,6 +370,10 @@ components:
                     x-go-type-skip-optional-pointer: true
                 updatedMetricKind:
                     $ref: '#/components/schemas/ApiMetricKind'
+                updatedSamplePeriod:
+                    type: string
+                    description: Override the sample period (Go duration string, e.g. "5m", "1h").
+                    x-go-type-skip-optional-pointer: true
                 updatedCustomMeta:
                     type: object
                     additionalProperties: true
@@ -717,6 +725,10 @@ components:
                     minLength: 1
                 metricKind:
                     $ref: '#/components/schemas/ApiMetricKind'
+                samplePeriod:
+                    type: string
+                    description: Expected reporting interval as a Go duration string (e.g., "5m", "1h"). For delta metrics, this declares the wall-clock window each sample covers.
+                    x-go-type-skip-optional-pointer: true
                 customMetadata:
                     type: object
                     additionalProperties: true

--- a/utils/timeseries/tsquery/queryopenapi/openapi_generated.gen.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_generated.gen.go
@@ -1002,8 +1002,11 @@ func (e ApiUnaryNumericOperatorReportFieldValueType) Valid() bool {
 type ApiAddFieldMeta struct {
 	CustomMetadata     map[string]interface{} `json:"customMetadata,omitempty"`
 	OverrideMetricKind ApiMetricKind          `json:"overrideMetricKind,omitempty"`
-	OverrideUnit       string                 `json:"overrideUnit,omitempty"`
-	Uri                string                 `json:"uri"`
+
+	// OverrideSamplePeriod Override the sample period for the output field (Go duration string, e.g. "5m", "1h").
+	OverrideSamplePeriod string `json:"overrideSamplePeriod,omitempty"`
+	OverrideUnit         string `json:"overrideUnit,omitempty"`
+	Uri                  string `json:"uri"`
 }
 
 // ApiAggregatedField A single aggregated scalar value with its metadata.
@@ -1563,8 +1566,11 @@ type ApiOverrideFieldMetadataFilter struct {
 	Type              ApiOverrideFieldMetadataFilterType `json:"type"`
 	UpdatedCustomMeta map[string]interface{}             `json:"updatedCustomMeta,omitempty"`
 	UpdatedMetricKind ApiMetricKind                      `json:"updatedMetricKind,omitempty"`
-	UpdatedUnit       string                             `json:"updatedUnit,omitempty"`
-	UpdatedUrn        string                             `json:"updatedUrn,omitempty"`
+
+	// UpdatedSamplePeriod Override the sample period (Go duration string, e.g. "5m", "1h").
+	UpdatedSamplePeriod string `json:"updatedSamplePeriod,omitempty"`
+	UpdatedUnit         string `json:"updatedUnit,omitempty"`
+	UpdatedUrn          string `json:"updatedUrn,omitempty"`
 }
 
 // ApiOverrideFieldMetadataFilterType defines model for ApiOverrideFieldMetadataFilter.Type.
@@ -1591,8 +1597,11 @@ type ApiQueryFieldMeta struct {
 	DataType       ApiMetricDataType      `json:"dataType"`
 	MetricKind     ApiMetricKind          `json:"metricKind,omitempty"`
 	Required       bool                   `json:"required"`
-	Unit           string                 `json:"unit,omitempty"`
-	Uri            string                 `json:"uri"`
+
+	// SamplePeriod Expected reporting interval as a Go duration string (e.g., "5m", "1h"). For delta metrics, this declares the wall-clock window each sample covers.
+	SamplePeriod string `json:"samplePeriod,omitempty"`
+	Unit         string `json:"unit,omitempty"`
+	Uri          string `json:"uri"`
 }
 
 // ApiQueryFieldValue defines model for ApiQueryFieldValue.

--- a/utils/timeseries/tsquery/queryopenapi/openapi_parser_datasource.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_parser_datasource.go
@@ -2,6 +2,8 @@ package queryopenapi
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/shpandrak/shpanstream/stream"
 	"github.com/shpandrak/shpanstream/utils/timeseries"
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
@@ -44,6 +46,13 @@ func parseStaticDatasource(ds ApiStaticQueryDatasource) (datasource.DataSource, 
 	)
 	if err != nil {
 		return nil, badInputErrorWrap(ds.FieldMeta, err, "failed to create field metadata for static datasource")
+	}
+	if ds.FieldMeta.SamplePeriod != "" {
+		sp, err := time.ParseDuration(ds.FieldMeta.SamplePeriod)
+		if err != nil {
+			return nil, badInputErrorWrap(ds.FieldMeta, err, "invalid samplePeriod")
+		}
+		*fieldMeta = fieldMeta.WithSamplePeriod(sp)
 	}
 
 	// Convert API data to timeseries records (single value per record)

--- a/utils/timeseries/tsquery/queryopenapi/openapi_parser_filter.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_parser_filter.go
@@ -67,10 +67,20 @@ func parseOverrideFieldMetadataFilter(overrideFilter ApiOverrideFieldMetadataFil
 		optUpdatedMetricKind = &overrideFilter.UpdatedMetricKind
 	}
 
+	var optUpdatedSamplePeriod *time.Duration
+	if overrideFilter.UpdatedSamplePeriod != "" {
+		sp, err := time.ParseDuration(overrideFilter.UpdatedSamplePeriod)
+		if err != nil {
+			return nil, badInputErrorWrap(overrideFilter, err, "invalid updatedSamplePeriod")
+		}
+		optUpdatedSamplePeriod = &sp
+	}
+
 	return datasource.NewOverrideFieldMetadataFilter(
 		optUpdatedUrn,
 		optUpdatedUnit,
 		optUpdatedMetricKind,
+		optUpdatedSamplePeriod,
 		overrideFilter.UpdatedCustomMeta,
 	), nil
 }
@@ -215,10 +225,11 @@ func parseCustomAlignmentPeriod(period ApiCustomAlignmentPeriod) (timeseries.Ali
 
 func ParseAddFieldMeta(apiMeta ApiAddFieldMeta) tsquery.AddFieldMeta {
 	return tsquery.AddFieldMeta{
-		Urn:                apiMeta.Uri,
-		CustomMeta:         apiMeta.CustomMetadata,
-		OverrideUnit:       apiMeta.OverrideUnit,
-		OverrideMetricKind: apiMeta.OverrideMetricKind,
+		Urn:                  apiMeta.Uri,
+		CustomMeta:           apiMeta.CustomMetadata,
+		OverrideUnit:         apiMeta.OverrideUnit,
+		OverrideMetricKind:   apiMeta.OverrideMetricKind,
+		OverrideSamplePeriod: apiMeta.OverrideSamplePeriod,
 	}
 }
 

--- a/utils/timeseries/tsquery/queryopenapi/openapi_parser_metric_kind_test.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_parser_metric_kind_test.go
@@ -172,3 +172,96 @@ func TestParseOverrideFieldMetadataFilter_UpdatedMetricKind(t *testing.T) {
 	// End-to-end verification that the filter actually applies the override is covered
 	// in datasource/metric_kind_propagation_test.go (TestOverrideFieldMetadataFilter_OverrideKind).
 }
+
+// --- SamplePeriod parsing tests ---
+
+// TestParseStaticDatasource_SamplePeriod verifies that samplePeriod on
+// ApiQueryFieldMeta flows through parseStaticDatasource into the resulting FieldMeta.
+func TestParseStaticDatasource_SamplePeriod(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	apiDs := ApiStaticQueryDatasource{
+		Type: "static",
+		FieldMeta: ApiQueryFieldMeta{
+			Uri:          "energy",
+			DataType:     tsquery.DataTypeDecimal,
+			Required:     true,
+			MetricKind:   tsquery.MetricKindDelta,
+			SamplePeriod: "5m",
+		},
+		Data: []ApiMeasurementValue{
+			{Timestamp: baseTime, Value: 1.0},
+		},
+	}
+
+	ds, err := parseStaticDatasource(apiDs)
+	require.NoError(t, err)
+
+	result, err := ds.Execute(testContext(), baseTime, baseTime.Add(1*time.Hour))
+	require.NoError(t, err)
+
+	meta := result.Meta()
+	assert.Equal(t, tsquery.MetricKindDelta, meta.MetricKind())
+	require.NotNil(t, meta.SamplePeriod())
+	assert.Equal(t, 5*time.Minute, *meta.SamplePeriod())
+}
+
+// TestParseStaticDatasource_SamplePeriod_Unset verifies that omitting samplePeriod
+// results in nil (backward compat).
+func TestParseStaticDatasource_SamplePeriod_Unset(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	apiDs := ApiStaticQueryDatasource{
+		Type: "static",
+		FieldMeta: ApiQueryFieldMeta{
+			Uri:      "temp",
+			DataType: tsquery.DataTypeDecimal,
+			Required: true,
+		},
+		Data: []ApiMeasurementValue{
+			{Timestamp: baseTime, Value: 1.0},
+		},
+	}
+
+	ds, err := parseStaticDatasource(apiDs)
+	require.NoError(t, err)
+
+	result, err := ds.Execute(testContext(), baseTime, baseTime.Add(1*time.Hour))
+	require.NoError(t, err)
+	assert.Nil(t, result.Meta().SamplePeriod())
+}
+
+// TestParseStaticDatasource_SamplePeriod_Invalid verifies that an invalid
+// samplePeriod string is rejected at parse time.
+func TestParseStaticDatasource_SamplePeriod_Invalid(t *testing.T) {
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	apiDs := ApiStaticQueryDatasource{
+		Type: "static",
+		FieldMeta: ApiQueryFieldMeta{
+			Uri:          "energy",
+			DataType:     tsquery.DataTypeDecimal,
+			Required:     true,
+			SamplePeriod: "not-a-duration",
+		},
+		Data: []ApiMeasurementValue{
+			{Timestamp: baseTime, Value: 1.0},
+		},
+	}
+
+	_, err := parseStaticDatasource(apiDs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "samplePeriod")
+}
+
+// TestParseAddFieldMeta_OverrideSamplePeriod verifies that overrideSamplePeriod
+// flows through ParseAddFieldMeta.
+func TestParseAddFieldMeta_OverrideSamplePeriod(t *testing.T) {
+	apiMeta := ApiAddFieldMeta{
+		Uri:                  "computed",
+		OverrideSamplePeriod: "15m",
+	}
+
+	parsed := ParseAddFieldMeta(apiMeta)
+	assert.Equal(t, "15m", parsed.OverrideSamplePeriod)
+}

--- a/utils/timeseries/tsquery/queryopenapi/openapi_parser_report_datasource.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_parser_report_datasource.go
@@ -2,6 +2,8 @@ package queryopenapi
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/shpandrak/shpanstream/stream"
 	"github.com/shpandrak/shpanstream/utils/timeseries"
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
@@ -46,6 +48,13 @@ func parseStaticReportDatasource(ds ApiStaticReportDatasource) (report.DataSourc
 		)
 		if err != nil {
 			return nil, badInputErrorWrap(fm, err, "failed to create field metadata %d for static report datasource", i)
+		}
+		if fm.SamplePeriod != "" {
+			sp, err := time.ParseDuration(fm.SamplePeriod)
+			if err != nil {
+				return nil, badInputErrorWrap(fm, err, "invalid samplePeriod for field %d", i)
+			}
+			*meta = meta.WithSamplePeriod(sp)
 		}
 		fieldsMeta[i] = *meta
 	}

--- a/utils/timeseries/tsquery/queryopenapi/tsquery-swagger.yaml
+++ b/utils/timeseries/tsquery/queryopenapi/tsquery-swagger.yaml
@@ -288,6 +288,10 @@ components:
           x-go-type-skip-optional-pointer: true
         overrideMetricKind:
           $ref: '#/components/schemas/ApiMetricKind'
+        overrideSamplePeriod:
+          type: string
+          description: Override the sample period for the output field (Go duration string, e.g. "5m", "1h").
+          x-go-type-skip-optional-pointer: true
         customMetadata:
           x-go-type-skip-optional-pointer: true
           type: object
@@ -341,6 +345,10 @@ components:
           x-go-type-skip-optional-pointer: true
         updatedMetricKind:
           $ref: '#/components/schemas/ApiMetricKind'
+        updatedSamplePeriod:
+          type: string
+          description: Override the sample period (Go duration string, e.g. "5m", "1h").
+          x-go-type-skip-optional-pointer: true
         updatedCustomMeta:
           type: object
           additionalProperties: true
@@ -846,6 +854,10 @@ components:
           minLength: 1
         metricKind:
           $ref: '#/components/schemas/ApiMetricKind'
+        samplePeriod:
+          type: string
+          description: Expected reporting interval as a Go duration string (e.g., "5m", "1h"). For delta metrics, this declares the wall-clock window each sample covers.
+          x-go-type-skip-optional-pointer: true
         customMetadata:
           type: object
           additionalProperties: true

--- a/utils/timeseries/tsquery/report/cast_field_report_value.go
+++ b/utils/timeseries/tsquery/report/cast_field_report_value.go
@@ -43,9 +43,10 @@ func (cf CastFieldValue) Execute(ctx context.Context, fieldsMeta []tsquery.Field
 
 	// Create field value metadata for the cast result
 	fieldValueMeta := tsquery.ValueMeta{
-		DataType:   cf.targetType,
-		MetricKind: sourceMeta.MetricKind,
-		Unit:       sourceMeta.Unit,
+		DataType:     cf.targetType,
+		MetricKind:   sourceMeta.MetricKind,
+		SamplePeriod: sourceMeta.SamplePeriod,
+		Unit:         sourceMeta.Unit,
 		Required:   sourceMeta.Required,
 		CustomMeta: sourceMeta.CustomMeta,
 	}

--- a/utils/timeseries/tsquery/report/metric_kind_propagation_test.go
+++ b/utils/timeseries/tsquery/report/metric_kind_propagation_test.go
@@ -128,7 +128,7 @@ func TestReportOverrideFieldMetadataFilter_OverridesKind(t *testing.T) {
 
 	// Override kind to Cumulative
 	cumKind := tsquery.MetricKindCumulative
-	filter := NewOverrideFieldMetadataFilter("metric", nil, nil, &cumKind, nil)
+	filter := NewOverrideFieldMetadataFilter("metric", nil, nil, &cumKind, nil, nil)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -158,7 +158,7 @@ func TestReportOverrideFieldMetadataFilter_PreservesKindWhenNil(t *testing.T) {
 
 	// Override URN but not kind
 	newUrn := "renamed"
-	filter := NewOverrideFieldMetadataFilter("metric", &newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter("metric", &newUrn, nil, nil, nil, nil)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 

--- a/utils/timeseries/tsquery/report/numeric_expression_report_field_value.go
+++ b/utils/timeseries/tsquery/report/numeric_expression_report_field_value.go
@@ -104,9 +104,10 @@ func (nef NumericExpressionFieldValue) Execute(ctx context.Context, fieldsMeta [
 
 	// Merge CustomMeta from both operands, op1 takes precedence on conflicts
 	fvm := tsquery.ValueMeta{
-		DataType:   promotedType,
-		MetricKind: op1Meta.MetricKind,
-		Unit:       updatedUnit,
+		DataType:     promotedType,
+		MetricKind:   op1Meta.MetricKind,
+		SamplePeriod: op1Meta.SamplePeriod,
+		Unit:         updatedUnit,
 		Required:   op1Meta.Required && op2Meta.Required,
 		CustomMeta: tsquery.MergeCustomMeta(op2Meta.CustomMeta, op1Meta.CustomMeta),
 	}

--- a/utils/timeseries/tsquery/report/nvl_report_field_value.go
+++ b/utils/timeseries/tsquery/report/nvl_report_field_value.go
@@ -56,9 +56,10 @@ func (nf NvlFieldValue) Execute(ctx context.Context, fieldsMeta []tsquery.FieldM
 	// Create field metadata - NVL field is always required since we have a fallback
 	// Propagate CustomMeta from source only (not from alt)
 	fvm := tsquery.ValueMeta{
-		DataType:   sourceType,
-		MetricKind: sourceMeta.MetricKind,
-		Unit:       sourceMeta.Unit,
+		DataType:     sourceType,
+		MetricKind:   sourceMeta.MetricKind,
+		SamplePeriod: sourceMeta.SamplePeriod,
+		Unit:         sourceMeta.Unit,
 		Required:   true,
 		CustomMeta: sourceMeta.CustomMeta,
 	}

--- a/utils/timeseries/tsquery/report/override_field_metadata_report_filter.go
+++ b/utils/timeseries/tsquery/report/override_field_metadata_report_filter.go
@@ -5,26 +5,29 @@ import (
 	"fmt"
 	"github.com/shpandrak/shpanstream/internal/util"
 	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
+	"time"
 )
 
 var _ Filter = OverrideFieldMetadataFilter{}
 
 // OverrideFieldMetadataFilter replaces the result stream with a single field extracted using the provided field.
 type OverrideFieldMetadataFilter struct {
-	fieldUrn             string
-	optUpdatedUrn        *string
-	optUpdatedUnit       *string
-	optUpdatedMetricKind *tsquery.MetricKind
-	optUpdatedCustomMeta map[string]any
+	fieldUrn               string
+	optUpdatedUrn          *string
+	optUpdatedUnit         *string
+	optUpdatedMetricKind   *tsquery.MetricKind
+	optUpdatedSamplePeriod *time.Duration
+	optUpdatedCustomMeta   map[string]any
 }
 
-func NewOverrideFieldMetadataFilter(fieldUrn string, optUpdatedUrn *string, optUpdatedUnit *string, optUpdatedMetricKind *tsquery.MetricKind, optUpdatedCustomMeta map[string]any) *OverrideFieldMetadataFilter {
+func NewOverrideFieldMetadataFilter(fieldUrn string, optUpdatedUrn *string, optUpdatedUnit *string, optUpdatedMetricKind *tsquery.MetricKind, optUpdatedSamplePeriod *time.Duration, optUpdatedCustomMeta map[string]any) *OverrideFieldMetadataFilter {
 	return &OverrideFieldMetadataFilter{
-		fieldUrn:             fieldUrn,
-		optUpdatedUrn:        optUpdatedUrn,
-		optUpdatedUnit:       optUpdatedUnit,
-		optUpdatedMetricKind: optUpdatedMetricKind,
-		optUpdatedCustomMeta: optUpdatedCustomMeta,
+		fieldUrn:               fieldUrn,
+		optUpdatedUrn:          optUpdatedUrn,
+		optUpdatedUnit:         optUpdatedUnit,
+		optUpdatedMetricKind:   optUpdatedMetricKind,
+		optUpdatedSamplePeriod: optUpdatedSamplePeriod,
+		optUpdatedCustomMeta:   optUpdatedCustomMeta,
 	}
 }
 
@@ -65,6 +68,12 @@ func (ofm OverrideFieldMetadataFilter) Filter(ctx context.Context, result Result
 		newMetricKind = *ofm.optUpdatedMetricKind
 	}
 
+	// Determine the new sample period
+	newSamplePeriod := originalFieldMeta.SamplePeriod()
+	if ofm.optUpdatedSamplePeriod != nil {
+		newSamplePeriod = ofm.optUpdatedSamplePeriod
+	}
+
 	// Merge custom metadata
 	var newCustomMeta map[string]any
 	if ofm.optUpdatedCustomMeta != nil {
@@ -85,6 +94,9 @@ func (ofm OverrideFieldMetadataFilter) Filter(ctx context.Context, result Result
 	)
 	if err != nil {
 		return util.DefaultValue[Result](), fmt.Errorf("failed to create updated field metadata: %w", err)
+	}
+	if newSamplePeriod != nil {
+		*updatedFieldMeta = updatedFieldMeta.WithSamplePeriod(*newSamplePeriod)
 	}
 
 	// Create new fields metadata slice with the updated field

--- a/utils/timeseries/tsquery/report/override_field_metadata_report_filter_test.go
+++ b/utils/timeseries/tsquery/report/override_field_metadata_report_filter_test.go
@@ -31,7 +31,7 @@ func TestOverrideFieldMetadataFilter_OverrideUrnOnly(t *testing.T) {
 
 	// Override URN only
 	newUrn := "renamed_field"
-	filter := NewOverrideFieldMetadataFilter("original_field", &newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter("original_field", &newUrn, nil, nil, nil, nil)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -73,7 +73,7 @@ func TestOverrideFieldMetadataFilter_OverrideUnitOnly(t *testing.T) {
 
 	// Override unit only
 	newUnit := "fahrenheit"
-	filter := NewOverrideFieldMetadataFilter("temperature", nil, &newUnit, nil, nil)
+	filter := NewOverrideFieldMetadataFilter("temperature", nil, &newUnit, nil, nil, nil)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -112,7 +112,7 @@ func TestOverrideFieldMetadataFilter_OverrideCustomMetaOnly(t *testing.T) {
 		"location": "room2",       // Override existing
 		"device":   "thermometer", // Add new
 	}
-	filter := NewOverrideFieldMetadataFilter("sensor_reading", nil, nil, nil, newCustomMeta)
+	filter := NewOverrideFieldMetadataFilter("sensor_reading", nil, nil, nil, nil, newCustomMeta)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -150,7 +150,7 @@ func TestOverrideFieldMetadataFilter_OverrideMultipleProperties(t *testing.T) {
 	newUnit := "new_unit"
 	newCustomMeta := map[string]any{"key2": "value2"}
 
-	filter := NewOverrideFieldMetadataFilter("old_name", &newUrn, &newUnit, nil, newCustomMeta)
+	filter := NewOverrideFieldMetadataFilter("old_name", &newUrn, &newUnit, nil, nil, newCustomMeta)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -184,7 +184,7 @@ func TestOverrideFieldMetadataFilter_NoOverrides(t *testing.T) {
 	result := NewResult([]tsquery.FieldMeta{*originalMeta}, stream.Just(records...))
 
 	// No overrides (all nil)
-	filter := NewOverrideFieldMetadataFilter("field_name", nil, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter("field_name", nil, nil, nil, nil, nil)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func TestOverrideFieldMetadataFilter_ErrorOnFieldNotFound(t *testing.T) {
 
 	// Try to override non-existent field
 	newUrn := "new_name"
-	filter := NewOverrideFieldMetadataFilter("non_existent_field", &newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter("non_existent_field", &newUrn, nil, nil, nil, nil)
 	_, err = filter.Filter(ctx, result)
 
 	// Verify error
@@ -238,7 +238,7 @@ func TestOverrideFieldMetadataFilter_WithMultipleFields(t *testing.T) {
 
 	// Override only the middle field
 	newUrn := "field2_renamed"
-	filter := NewOverrideFieldMetadataFilter("field2", &newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter("field2", &newUrn, nil, nil, nil, nil)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -288,7 +288,7 @@ func TestOverrideFieldMetadataFilter_DataTypeAndRequiredUnchanged(t *testing.T) 
 				// Try to override other fields
 				newUrn := "new_field"
 				newUnit := "new_unit"
-				filter := NewOverrideFieldMetadataFilter("field", &newUrn, &newUnit, nil, nil)
+				filter := NewOverrideFieldMetadataFilter("field", &newUrn, &newUnit, nil, nil, nil)
 				filteredResult, err := filter.Filter(ctx, result)
 				require.NoError(t, err)
 
@@ -318,7 +318,7 @@ func TestOverrideFieldMetadataFilter_EmptyCustomMeta(t *testing.T) {
 
 	// Add custom metadata
 	newCustomMeta := map[string]any{"key": "value"}
-	filter := NewOverrideFieldMetadataFilter("field", nil, nil, nil, newCustomMeta)
+	filter := NewOverrideFieldMetadataFilter("field", nil, nil, nil, nil, newCustomMeta)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -343,7 +343,7 @@ func TestOverrideFieldMetadataFilter_PreservesStreamData(t *testing.T) {
 
 	// Override metadata
 	newUrn := "renamed"
-	filter := NewOverrideFieldMetadataFilter("field", &newUrn, nil, nil, nil)
+	filter := NewOverrideFieldMetadataFilter("field", &newUrn, nil, nil, nil, nil)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 
@@ -378,7 +378,7 @@ func TestOverrideFieldMetadataFilter_OverrideUnitToEmpty(t *testing.T) {
 
 	// Override unit to empty string
 	emptyUnit := ""
-	filter := NewOverrideFieldMetadataFilter("field", nil, &emptyUnit, nil, nil)
+	filter := NewOverrideFieldMetadataFilter("field", nil, &emptyUnit, nil, nil, nil)
 	filteredResult, err := filter.Filter(ctx, result)
 	require.NoError(t, err)
 

--- a/utils/timeseries/tsquery/report/ref_report_field_value.go
+++ b/utils/timeseries/tsquery/report/ref_report_field_value.go
@@ -29,9 +29,10 @@ func (rf RefFieldValue) Execute(ctx context.Context, fieldsMeta []tsquery.FieldM
 	}
 
 	return tsquery.ValueMeta{
-		DataType:   fm.DataType(),
-		MetricKind: fm.MetricKind(),
-		Unit:       fm.Unit(),
+		DataType:     fm.DataType(),
+		MetricKind:   fm.MetricKind(),
+		SamplePeriod: fm.SamplePeriod(),
+		Unit:         fm.Unit(),
 		Required:   fm.Required(),
 		CustomMeta: fm.CustomMeta(),
 	}, valueSupplier, nil

--- a/utils/timeseries/tsquery/report/report_filter.go
+++ b/utils/timeseries/tsquery/report/report_filter.go
@@ -26,6 +26,17 @@ func PrepareField(
 	if meta.OverrideMetricKind != "" {
 		metricKind = meta.OverrideMetricKind
 	}
+	var samplePeriod *time.Duration
+	if valueMeta.SamplePeriod != nil {
+		samplePeriod = valueMeta.SamplePeriod
+	}
+	if meta.OverrideSamplePeriod != "" {
+		sp, err := time.ParseDuration(meta.OverrideSamplePeriod)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid OverrideSamplePeriod for field %s: %w", meta.Urn, err)
+		}
+		samplePeriod = &sp
+	}
 	fm, err := tsquery.NewFieldMetaFull(
 		meta.Urn,
 		valueMeta.DataType,
@@ -36,6 +47,9 @@ func PrepareField(
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed creating field meta for %s: %w", meta.Urn, err)
+	}
+	if samplePeriod != nil {
+		*fm = fm.WithSamplePeriod(*samplePeriod)
 	}
 	return fm, valueSupplier, nil
 

--- a/utils/timeseries/tsquery/report/selector_report_field_value.go
+++ b/utils/timeseries/tsquery/report/selector_report_field_value.go
@@ -90,9 +90,10 @@ func (cf SelectorFieldValue) Execute(ctx context.Context, fieldsMeta []tsquery.F
 
 	// Create field metadata
 	fvm := tsquery.ValueMeta{
-		DataType:   trueType,
-		MetricKind: trueMeta.MetricKind,
-		Unit:       trueMeta.Unit,
+		DataType:     trueType,
+		MetricKind:   trueMeta.MetricKind,
+		SamplePeriod: trueMeta.SamplePeriod,
+		Unit:         trueMeta.Unit,
 		Required:   trueMeta.Required,
 	}
 

--- a/utils/timeseries/tsquery/report/unary_numeric_report_operator_field_value.go
+++ b/utils/timeseries/tsquery/report/unary_numeric_report_operator_field_value.go
@@ -45,9 +45,10 @@ func (ufv UnaryNumericOperatorFieldValue) Execute(ctx context.Context, fieldsMet
 	}
 
 	fvm := tsquery.ValueMeta{
-		DataType:   dt,
-		MetricKind: operandMeta.MetricKind,
-		Unit:       operandMeta.Unit,
+		DataType:     dt,
+		MetricKind:   operandMeta.MetricKind,
+		SamplePeriod: operandMeta.SamplePeriod,
+		Unit:         operandMeta.Unit,
 		Required:   operandMeta.Required,
 		CustomMeta: operandMeta.CustomMeta,
 	}

--- a/utils/timeseries/tsquery/time_series_query.go
+++ b/utils/timeseries/tsquery/time_series_query.go
@@ -2,18 +2,21 @@ package tsquery
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/shpandrak/shpanstream/utils/timeseries"
 )
 
 type Record timeseries.TsRecord[[]any]
 
 type FieldMeta struct {
-	urn        string
-	dataType   DataType
-	metricKind MetricKind
-	unit       string
-	required   bool
-	customMeta map[string]any
+	urn          string
+	dataType     DataType
+	metricKind   MetricKind
+	samplePeriod *time.Duration
+	unit         string
+	required     bool
+	customMeta   map[string]any
 }
 
 func (fm FieldMeta) GetCustomMetaStringValue(key string) string {
@@ -45,6 +48,15 @@ func (fm FieldMeta) MetricKind() MetricKind {
 
 func (fm FieldMeta) WithMetricKind(kind MetricKind) FieldMeta {
 	fm.metricKind = kind
+	return fm
+}
+
+func (fm FieldMeta) SamplePeriod() *time.Duration {
+	return fm.samplePeriod
+}
+
+func (fm FieldMeta) WithSamplePeriod(d time.Duration) FieldMeta {
+	fm.samplePeriod = &d
 	return fm
 }
 
@@ -108,16 +120,18 @@ func NewFieldMetaFull(
 }
 
 type ValueMeta struct {
-	DataType   DataType
-	MetricKind MetricKind
-	Unit       string
-	Required   bool
-	CustomMeta map[string]any
+	DataType     DataType
+	MetricKind   MetricKind
+	SamplePeriod *time.Duration
+	Unit         string
+	Required     bool
+	CustomMeta   map[string]any
 }
 
 type AddFieldMeta struct {
-	Urn                string
-	CustomMeta         map[string]any
-	OverrideUnit       string
-	OverrideMetricKind MetricKind
+	Urn                  string
+	CustomMeta           map[string]any
+	OverrideUnit         string
+	OverrideMetricKind   MetricKind
+	OverrideSamplePeriod string
 }


### PR DESCRIPTION
Adds an optional samplePeriod (*time.Duration) to FieldMeta, declaring the expected reporting interval for a metric (e.g., "5m" for 5-minute energy consumption deltas). This enables Phase 2's smart aligner to detect missing samples and prorate during delta bucketing.

Industry context: OpenTelemetry carries start/end timestamps per delta point; Prometheus extrapolates; Google Cloud interpolates missing periods. Our approach is lighter — metadata on the field, not per-point timestamps — but enables the same downstream decisions.

- FieldMeta.SamplePeriod() getter (nil when unset)
- FieldMeta.WithSamplePeriod(d) builder (value receiver, returns copy)
- ValueMeta.SamplePeriod for report field value propagation
- AddFieldMeta.OverrideSamplePeriod (Go duration string)
- OpenAPI: samplePeriod on ApiQueryFieldMeta, overrideSamplePeriod on ApiAddFieldMeta, updatedSamplePeriod on ApiOverrideFieldMetadataFilter
- All field values propagate samplePeriod (same pattern as MetricKind)
- DeltaFilter preserves samplePeriod; RateFilter clears it (nil)
- AlignerFilter preserves samplePeriod + Phase 2 TODO for gap detection
- OverrideFieldMetadataFilter (datasource + report) supports override
- New tests: getter/builder, filter propagation, JSON round-trip