### PR TITLE
Guard division and modulo operators against division by zero

### DIFF
--- a/utils/timeseries/tsquery/numeric_operators.go
+++ b/utils/timeseries/tsquery/numeric_operators.go
@@ -8,6 +8,13 @@ import (
 
 type BinaryNumericOperatorType string
 
+// DivisionByZeroError is a typed panic used by division and modulo operators
+// when the divisor is zero. The stream framework's recover() catches this and
+// surfaces it as a regular error.
+type DivisionByZeroError struct{}
+
+func (e DivisionByZeroError) Error() string { return "division by zero" }
+
 // Integer operations
 
 func AddInt(v1, v2 any) any {
@@ -23,10 +30,16 @@ func MulInt(v1, v2 any) any {
 }
 
 func DivInt(v1, v2 any) any {
+	if v2.(int64) == 0 {
+		panic(DivisionByZeroError{})
+	}
 	return v1.(int64) / v2.(int64)
 }
 
 func ModInt(v1, v2 any) any {
+	if v2.(int64) == 0 {
+		panic(DivisionByZeroError{})
+	}
 	return v1.(int64) % v2.(int64)
 }
 
@@ -49,6 +62,9 @@ func MulDecimal(v1, v2 any) any {
 }
 
 func DivDecimal(v1, v2 any) any {
+	if v2.(float64) == 0 {
+		panic(DivisionByZeroError{})
+	}
 	return v1.(float64) / v2.(float64)
 }
 

--- a/utils/timeseries/tsquery/numeric_operators_test.go
+++ b/utils/timeseries/tsquery/numeric_operators_test.go
@@ -2,6 +2,8 @@ package tsquery
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBinaryNumericOperatorType_Validate_Valid(t *testing.T) {
@@ -68,4 +70,37 @@ func TestUnaryNumericOperatorType_Validate_Invalid(t *testing.T) {
 			t.Errorf("expected invalid operator %q to fail validation, but got nil", op)
 		}
 	}
+}
+
+func TestDivInt_DivisionByZero_Panics(t *testing.T) {
+	require.PanicsWithValue(t, DivisionByZeroError{}, func() {
+		DivInt(int64(10), int64(0))
+	})
+}
+
+func TestDivDecimal_DivisionByZero_Panics(t *testing.T) {
+	require.PanicsWithValue(t, DivisionByZeroError{}, func() {
+		DivDecimal(float64(10), float64(0))
+	})
+}
+
+func TestModInt_DivisionByZero_Panics(t *testing.T) {
+	require.PanicsWithValue(t, DivisionByZeroError{}, func() {
+		ModInt(int64(10), int64(0))
+	})
+}
+
+func TestDivInt_ValidDivision(t *testing.T) {
+	result := DivInt(int64(10), int64(3))
+	require.Equal(t, int64(3), result)
+}
+
+func TestDivDecimal_ValidDivision(t *testing.T) {
+	result := DivDecimal(float64(10), float64(3))
+	require.InDelta(t, 3.3333333, result, 0.0001)
+}
+
+func TestModInt_ValidMod(t *testing.T) {
+	result := ModInt(int64(10), int64(3))
+	require.Equal(t, int64(1), result)
 }


### PR DESCRIPTION
DivInt and ModInt panicked with a raw runtime error on zero divisor. DivDecimal produced +Inf which breaks json.Marshal, causing API serialization errors. All three now panic with a typed DivisionByZeroError that the stream framework's recover() catches and surfaces as a regular error.