### PR TITLE
Add MetricKind Phase 1b + Phase 2: kind-aware filters, validation, an…

### DIFF
--- a/docs/metric-kind-plan.md
+++ b/docs/metric-kind-plan.md
@@ -405,7 +405,33 @@ Uncomment the Phase 1 TODOs:
 - Error on `MetricKindDelta` input (already delta)
 - Only accept `MetricKindCumulative` (and unspecified for backward compat -- but unspecified returns gauge, so this effectively requires explicit cumulative)
 
-### 2.3 Selector field value strict kind validation
+### 2.3 RateFilter input validation
+
+RateFilter rejects `MetricKindRate` input with error: `"rate filter cannot be applied to data that is already a rate"`. All other kinds (Gauge, Delta, Cumulative) are accepted -- computing a rate is valid for any of them.
+
+### 2.4 Implicit gap threshold from `samplePeriod`
+
+When no explicit `maxGapDuration` is set, DeltaFilter and RateFilter auto-compute a gap threshold of `2 × samplePeriod`. If a gap between consecutive data points exceeds this threshold, the point is treated as a new baseline (no delta/rate emitted for the gap).
+
+- Explicit `maxGapDuration` always wins (overrides the implicit threshold)
+- No `samplePeriod` and no `maxGapDuration` → no gap detection (backward compatible)
+- Applied identically in both DeltaFilter and RateFilter
+
+**Why:** Delta and rate computations across large gaps produce misleading values (e.g., a 12-hour delta from a 5-minute counter). The `2×` multiplier tolerates one missed sample while catching genuine outages.
+
+### 2.5 AlignerFilter output `samplePeriod` derivation
+
+After alignment, the output `samplePeriod` is set to the alignment period duration (for fixed-duration periods). For calendar-based alignment periods (e.g., monthly), `samplePeriod` is cleared (nil) because the period cannot be expressed as a fixed `time.Duration`.
+
+This replaces the Phase 1 behavior of preserving the input `samplePeriod` through the bucket reduction path. The alignment period IS the output cadence -- the input sample period is no longer meaningful after alignment.
+
+### 2.6 `RawMetricKind()` getter on `FieldMeta`
+
+A new `RawMetricKind()` method returns the metric kind as-declared, without normalization (returns `""` if unset). This contrasts with `MetricKind()` which returns `MetricKindGauge` for unset fields.
+
+Used by `RefFieldValue` (both datasource and report sides) to propagate the unset-vs-explicit distinction through `ValueMeta`. This is critical for selector validation: unset kind is "transparent" (compatible with any kind), while explicit `MetricKindGauge` is not compatible with `MetricKindDelta`.
+
+### 2.7 Selector field value strict kind validation
 
 Selector field values (`if condition then trueField else falseField`) currently validate that the true and false branches have matching `DataType` and `Required` status (`selector_field_value.go:83-88`). Phase 2 extends this validation to require matching `MetricKind`:
 
@@ -420,7 +446,7 @@ Selector field values (`if condition then trueField else falseField`) currently 
 
 Apply to both datasource-side (`selector_field_value.go`) and report-side (`selector_report_field_value.go`) selectors.
 
-### 2.4 Test: cumulative-to-aligned-delta (the golden test case)
+### 2.8 Test: cumulative-to-aligned-delta (the golden test case)
 
 ```go
 func TestCumulativeToAlignedDelta(t *testing.T) {
@@ -453,7 +479,7 @@ func TestCumulativeToAlignedDelta(t *testing.T) {
 }
 ```
 
-### 2.5 Test: gauge through same aligner (contrast test)
+### 2.9 Test: gauge through same aligner (contrast test)
 
 ```go
 func TestGaugeAlignedDefaultAvg(t *testing.T) {
@@ -465,7 +491,7 @@ func TestGaugeAlignedDefaultAvg(t *testing.T) {
 }
 ```
 
-### 2.6 Test: explicit bucketReduction overrides kind
+### 2.10 Test: explicit bucketReduction overrides kind
 
 ```go
 func TestExplicitReductionOverridesKind(t *testing.T) {
@@ -501,8 +527,12 @@ func TestExplicitReductionOverridesKind(t *testing.T) {
 ### Phase 2
 | File | Change |
 |------|--------|
-| `utils/timeseries/tsquery/datasource/aligner_filter.go` | Uncomment smart defaults, implement kind-aware path |
-| `utils/timeseries/tsquery/datasource/delta_filter.go` | Uncomment input validation |
-| `utils/timeseries/tsquery/datasource/selector_field_value.go` | Add strict MetricKind matching validation between true/false branches |
-| `utils/timeseries/tsquery/report/selector_report_field_value.go` | Add strict MetricKind matching validation between true/false branches |
-| Test files | Golden test cases (cumulative->aligned-delta, gauge contrast, explicit override, selector kind mismatch) |
+| `utils/timeseries/tsquery/time_series_query.go` | Add `RawMetricKind()` getter |
+| `utils/timeseries/tsquery/datasource/aligner_filter.go` | Uncomment smart defaults; derive output samplePeriod from alignment period |
+| `utils/timeseries/tsquery/datasource/delta_filter.go` | Uncomment input validation; add implicit gap threshold from samplePeriod |
+| `utils/timeseries/tsquery/datasource/rate_filter.go` | Reject rate-of-rate; add implicit gap threshold from samplePeriod |
+| `utils/timeseries/tsquery/datasource/ref_field_value.go` | Use `RawMetricKind()` to preserve unset-vs-explicit distinction |
+| `utils/timeseries/tsquery/datasource/selector_field_value.go` | Add strict MetricKind matching with transparent-unset merge |
+| `utils/timeseries/tsquery/report/ref_report_field_value.go` | Use `RawMetricKind()` to preserve unset-vs-explicit distinction |
+| `utils/timeseries/tsquery/report/selector_report_field_value.go` | Add strict MetricKind matching with transparent-unset merge |
+| Test files | Golden test cases, gap threshold edge cases, selector kind merge, untagged metric rejection |

--- a/utils/timeseries/tsquery/datasource/aligner_filter.go
+++ b/utils/timeseries/tsquery/datasource/aligner_filter.go
@@ -46,22 +46,18 @@ func (af AlignerFilter) BucketReduction() *tsquery.ReductionType {
 func (af AlignerFilter) Filter(_ context.Context, result Result) (Result, error) {
 	isNumeric := result.meta.DataType().IsNumeric()
 
-	// TODO Phase 2: kind-aware default bucket reduction
-	// When no explicit bucketReduction is set, choose default based on MetricKind:
-	//   Delta       → Sum (delta values are additive within a bucket)
-	//   Cumulative  → Last (last counter reading in bucket)
-	//   Gauge, Rate → time-weighted average (existing default behavior)
-	//
-	// if af.bucketReduction == nil {
-	// 	switch result.meta.MetricKind() {
-	// 	case tsquery.MetricKindDelta:
-	// 		sum := tsquery.ReductionTypeSum
-	// 		af.bucketReduction = &sum
-	// 	case tsquery.MetricKindCumulative:
-	// 		last := tsquery.ReductionTypeLast
-	// 		af.bucketReduction = &last
-	// 	}
-	// }
+	// Kind-aware default bucket reduction: when no explicit bucketReduction is set,
+	// choose default based on MetricKind. Gauge/Rate use the existing interpolation path.
+	if af.bucketReduction == nil {
+		switch result.meta.MetricKind() {
+		case tsquery.MetricKindDelta:
+			sum := tsquery.ReductionTypeSum
+			af.bucketReduction = &sum
+		case tsquery.MetricKindCumulative:
+			last := tsquery.ReductionTypeLast
+			af.bucketReduction = &last
+		}
+	}
 
 	// Validate bucket reduction compatibility (must come before fill mode check)
 	if af.bucketReduction != nil && af.bucketReduction.RequiresNumeric() && !isNumeric {
@@ -101,10 +97,6 @@ func (af AlignerFilter) Filter(_ context.Context, result Result) (Result, error)
 			if err != nil {
 				return util.DefaultValue[Result](), fmt.Errorf("failed to create new field meta for bucket reduction: %w", err)
 			}
-			if sp := result.meta.SamplePeriod(); sp != nil {
-				*newMeta = newMeta.WithSamplePeriod(*sp)
-			}
-			// TODO Phase 2: derive samplePeriod from alignment period when bucket reduction changes the effective cadence
 			resultMeta = *newMeta
 		}
 	}
@@ -210,6 +202,11 @@ func (af AlignerFilter) Filter(_ context.Context, result Result) (Result, error)
 			alignmentPeriodClassifierFunc[any](af.alignmentPeriod),
 			result.data,
 		)
+	}
+
+	// Derive output samplePeriod from alignment period (the output cadence is now the alignment period)
+	if fixedPeriod, ok := af.alignmentPeriod.(timeseries.FixedAlignmentPeriod); ok {
+		resultMeta = resultMeta.WithSamplePeriod(fixedPeriod.Duration)
 	}
 
 	// If fillMode is set, wrap the sparse aligned stream with a gap-filler

--- a/utils/timeseries/tsquery/datasource/delta_filter.go
+++ b/utils/timeseries/tsquery/datasource/delta_filter.go
@@ -43,17 +43,17 @@ func (df DeltaFilter) Filter(_ context.Context, result Result) (Result, error) {
 		)
 	}
 
-	// TODO Phase 2: validate input kind
-	// inputKind := result.meta.MetricKind()
-	// if inputKind == tsquery.MetricKindGauge {
-	// 	return util.DefaultValue[Result](), fmt.Errorf("delta filter cannot be applied to gauge metrics; set metricKind to cumulative on the datasource")
-	// }
-	// if inputKind == tsquery.MetricKindDelta {
-	// 	return util.DefaultValue[Result](), fmt.Errorf("delta filter cannot be applied to data that is already delta")
-	// }
-	// if inputKind == tsquery.MetricKindRate {
-	// 	return util.DefaultValue[Result](), fmt.Errorf("delta filter cannot be applied to rate metrics")
-	// }
+	// Validate input kind
+	inputKind := result.meta.MetricKind()
+	if inputKind == tsquery.MetricKindGauge {
+		return util.DefaultValue[Result](), fmt.Errorf("delta filter cannot be applied to gauge metrics; set metricKind to cumulative on the datasource")
+	}
+	if inputKind == tsquery.MetricKindDelta {
+		return util.DefaultValue[Result](), fmt.Errorf("delta filter cannot be applied to data that is already delta")
+	}
+	if inputKind == tsquery.MetricKindRate {
+		return util.DefaultValue[Result](), fmt.Errorf("delta filter cannot be applied to rate metrics")
+	}
 
 	// Set output kind to Delta — the output represents per-interval changes
 	outputMeta := result.meta.WithMetricKind(tsquery.MetricKindDelta)
@@ -61,6 +61,15 @@ func (df DeltaFilter) Filter(_ context.Context, result Result) (Result, error) {
 	subFunc, err := tsquery.BinaryNumericOperatorSub.GetFuncImpl(dataType)
 	if err != nil {
 		return util.DefaultValue[Result](), fmt.Errorf("failed to get subtraction function: %w", err)
+	}
+
+	// Implicit gap threshold: when no explicit maxGapDuration, use 2×samplePeriod
+	effectiveMaxGap := df.optMaxGapDuration
+	if effectiveMaxGap == nil {
+		if sp := result.meta.SamplePeriod(); sp != nil {
+			defaultGap := *sp * 2
+			effectiveMaxGap = &defaultGap
+		}
 	}
 
 	var prevItem *timeseries.TsRecord[any]
@@ -79,7 +88,7 @@ func (df DeltaFilter) Filter(_ context.Context, result Result) (Result, error) {
 					}
 
 					// Gap detection: if gap exceeds threshold, treat as new baseline
-					if df.optMaxGapDuration != nil && item.Timestamp.Sub(prevItem.Timestamp) > *df.optMaxGapDuration {
+					if effectiveMaxGap != nil && item.Timestamp.Sub(prevItem.Timestamp) > *effectiveMaxGap {
 						prevItem = &item
 						return nil, nil
 					}
@@ -135,7 +144,7 @@ func (df DeltaFilter) Filter(_ context.Context, result Result) (Result, error) {
 				}
 
 				// Gap detection: if gap exceeds threshold, treat as new baseline
-				if df.optMaxGapDuration != nil && item.Timestamp.Sub(prevItem.Timestamp) > *df.optMaxGapDuration {
+				if effectiveMaxGap != nil && item.Timestamp.Sub(prevItem.Timestamp) > *effectiveMaxGap {
 					prevItem = &item
 					return nil, nil
 				}

--- a/utils/timeseries/tsquery/datasource/metric_kind_phase2_test.go
+++ b/utils/timeseries/tsquery/datasource/metric_kind_phase2_test.go
@@ -1,0 +1,683 @@
+package datasource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shpandrak/shpanstream/stream"
+	"github.com/shpandrak/shpanstream/utils/timeseries"
+	"github.com/shpandrak/shpanstream/utils/timeseries/tsquery"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Aligner smart defaults ---
+
+func TestAlignerFilter_AutoSum_DeltaInOneBucket(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("energy", tsquery.DataTypeDecimal, tsquery.MetricKindDelta, true, "kWh", nil)
+	require.NoError(t, err)
+
+	// Three delta values all within a single 15-minute bucket
+	records := []timeseries.TsRecord[any]{
+		{Value: 10.0, Timestamp: time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)},
+		{Value: 15.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 20.0, Timestamp: time.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC))
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindDelta, filtered.Meta().MetricKind())
+
+	collected := filtered.Data().MustCollect()
+	require.Len(t, collected, 1)
+	require.Equal(t, 45.0, collected[0].Value) // 10 + 15 + 20
+}
+
+func TestAlignerFilter_AutoSum_DeltaMultipleBuckets(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("energy", tsquery.DataTypeDecimal, tsquery.MetricKindDelta, true, "kWh", nil)
+	require.NoError(t, err)
+
+	// Delta values spanning two 15-minute buckets
+	records := []timeseries.TsRecord[any]{
+		{Value: 10.0, Timestamp: time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)},  // bucket [0:00-0:15)
+		{Value: 15.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},  // bucket [0:00-0:15)
+		{Value: 20.0, Timestamp: time.Date(2024, 1, 1, 0, 16, 0, 0, time.UTC)}, // bucket [0:15-0:30)
+		{Value: 25.0, Timestamp: time.Date(2024, 1, 1, 0, 20, 0, 0, time.UTC)}, // bucket [0:15-0:30)
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC))
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	require.Len(t, collected, 2)
+	require.Equal(t, 25.0, collected[0].Value) // 10 + 15
+	require.Equal(t, 45.0, collected[1].Value) // 20 + 25
+}
+
+func TestAlignerFilter_AutoLast_CumulativeInOneBucket(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("counter", tsquery.DataTypeDecimal, tsquery.MetricKindCumulative, true, "kWh", nil)
+	require.NoError(t, err)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 125.0, Timestamp: time.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC))
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindCumulative, filtered.Meta().MetricKind())
+
+	collected := filtered.Data().MustCollect()
+	require.Len(t, collected, 1)
+	require.Equal(t, 125.0, collected[0].Value) // last value in bucket
+}
+
+func TestAlignerFilter_AutoLast_CumulativeStandaloneDownsampling(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("counter", tsquery.DataTypeDecimal, tsquery.MetricKindCumulative, true, "kWh", nil)
+	require.NoError(t, err)
+
+	// Cumulative counter across two 15-minute buckets (no DeltaFilter)
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC)},
+		{Value: 125.0, Timestamp: time.Date(2024, 1, 1, 0, 16, 0, 0, time.UTC)},
+		{Value: 140.0, Timestamp: time.Date(2024, 1, 1, 0, 25, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC))
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	require.Len(t, collected, 2)
+	require.Equal(t, 110.0, collected[0].Value) // last in [0:00-0:15)
+	require.Equal(t, 140.0, collected[1].Value) // last in [0:15-0:30)
+}
+
+func TestAlignerFilter_ExplicitOverridesAutoSum(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("energy", tsquery.DataTypeDecimal, tsquery.MetricKindDelta, true, "kWh", nil)
+	require.NoError(t, err)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 10.0, Timestamp: time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)},
+		{Value: 20.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	// Explicit Avg overrides auto-Sum for delta
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC)).
+		WithBucketReduction(tsquery.ReductionTypeAvg)
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	require.Len(t, collected, 1)
+	require.Equal(t, 15.0, collected[0].Value) // avg(10, 20) = 15
+}
+
+func TestAlignerFilter_ExplicitOverridesAutoLast(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("counter", tsquery.DataTypeDecimal, tsquery.MetricKindCumulative, true, "kWh", nil)
+	require.NoError(t, err)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)},
+		{Value: 200.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	// Explicit Sum overrides auto-Last for cumulative
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC)).
+		WithBucketReduction(tsquery.ReductionTypeSum)
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	require.Len(t, collected, 1)
+	require.Equal(t, 300.0, collected[0].Value) // sum(100, 200) = 300
+}
+
+// --- Aligner output samplePeriod ---
+
+func TestAlignerFilter_OutputSamplePeriod_FixedPeriod(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("temp", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "", nil)
+	require.NoError(t, err)
+
+	result := Result{meta: *fm, data: simpleStream(1, 2, 3)}
+
+	fifteenMin := 15 * time.Minute
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(fifteenMin, time.UTC))
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+	require.NotNil(t, filtered.Meta().SamplePeriod())
+	require.Equal(t, fifteenMin, *filtered.Meta().SamplePeriod())
+}
+
+func TestAlignerFilter_OutputSamplePeriod_CalendarPeriod(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("temp", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "", nil)
+	require.NoError(t, err)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 1.0, Timestamp: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)},
+		{Value: 2.0, Timestamp: time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	af := NewAlignerFilter(timeseries.NewMonthAlignmentPeriod(time.UTC))
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+	// Calendar-based alignment cannot express duration as time.Duration
+	require.Nil(t, filtered.Meta().SamplePeriod())
+}
+
+// --- DeltaFilter validation ---
+
+func TestDeltaFilter_RejectsDeltaInput(t *testing.T) {
+	ctx := context.Background()
+	meta := deltaDecimalMeta(t)
+	result := Result{meta: meta, data: simpleStream(10, 15, 20)}
+
+	df := NewDeltaFilter(false, 0, false, nil)
+	_, err := df.Filter(ctx, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already delta")
+}
+
+func TestDeltaFilter_RejectsRateInput(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("rate_field", tsquery.DataTypeDecimal, tsquery.MetricKindRate, true, "", nil)
+	require.NoError(t, err)
+	result := Result{meta: *fm, data: simpleStream(1, 2, 3)}
+
+	df := NewDeltaFilter(false, 0, false, nil)
+	_, err = df.Filter(ctx, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rate")
+}
+
+func TestDeltaFilter_RejectsUntaggedInput(t *testing.T) {
+	// A metric created with NewFieldMeta (no explicit kind) defaults to gauge
+	// and must be rejected by DeltaFilter with a clear error message.
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMeta("untagged_counter", tsquery.DataTypeDecimal, true)
+	require.NoError(t, err)
+	result := Result{meta: *fm, data: simpleStream(100, 110, 125)}
+
+	df := NewDeltaFilter(false, 0, false, nil)
+	_, err = df.Filter(ctx, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gauge")
+	require.Contains(t, err.Error(), "set metricKind to cumulative")
+}
+
+// --- DeltaFilter implicit gap threshold ---
+
+func TestDeltaFilter_ImplicitGap_DetectsGap(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	meta := cumulativeDecimalMeta(t).WithSamplePeriod(fiveMin)
+
+	// 5m intervals, but 12m gap between second and third sample
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 200.0, Timestamp: time.Date(2024, 1, 1, 0, 17, 0, 0, time.UTC)}, // 12m gap > 10m threshold
+		{Value: 215.0, Timestamp: time.Date(2024, 1, 1, 0, 22, 0, 0, time.UTC)},
+	}
+	result := Result{meta: meta, data: stream.Just(records...)}
+
+	df := NewDeltaFilter(false, 0, false, nil) // no explicit maxGap
+	filtered, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	// First delta: 110-100=10, gap delta skipped, third delta: 215-200=15
+	require.Len(t, collected, 2)
+	require.Equal(t, 10.0, collected[0].Value)
+	require.Equal(t, 15.0, collected[1].Value)
+}
+
+func TestDeltaFilter_ImplicitGap_ExactlyTwoXIsNotGap(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	meta := cumulativeDecimalMeta(t).WithSamplePeriod(fiveMin)
+
+	// Gap is exactly 10m (2×5m) — code uses >, so exactly 10m is NOT a gap
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 130.0, Timestamp: time.Date(2024, 1, 1, 0, 15, 0, 0, time.UTC)}, // exactly 10m gap
+		{Value: 145.0, Timestamp: time.Date(2024, 1, 1, 0, 20, 0, 0, time.UTC)},
+	}
+	result := Result{meta: meta, data: stream.Just(records...)}
+
+	df := NewDeltaFilter(false, 0, false, nil)
+	filtered, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	// All deltas computed: 10, 20, 15
+	require.Len(t, collected, 3)
+	require.Equal(t, 10.0, collected[0].Value)
+	require.Equal(t, 20.0, collected[1].Value) // 130-110, NOT skipped
+	require.Equal(t, 15.0, collected[2].Value)
+}
+
+func TestDeltaFilter_ImplicitGap_JustOverTwoXIsGap(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	meta := cumulativeDecimalMeta(t).WithSamplePeriod(fiveMin)
+
+	// Gap is 10m01s — just over threshold
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 200.0, Timestamp: time.Date(2024, 1, 1, 0, 15, 1, 0, time.UTC)}, // 10m01s gap
+		{Value: 215.0, Timestamp: time.Date(2024, 1, 1, 0, 20, 1, 0, time.UTC)},
+	}
+	result := Result{meta: meta, data: stream.Just(records...)}
+
+	df := NewDeltaFilter(false, 0, false, nil)
+	filtered, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	// Gap detected, delta skipped: 10, then 15
+	require.Len(t, collected, 2)
+	require.Equal(t, 10.0, collected[0].Value)
+	require.Equal(t, 15.0, collected[1].Value)
+}
+
+func TestDeltaFilter_ImplicitGap_ExplicitMaxGapWins(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	twentyMin := 20 * time.Minute
+	meta := cumulativeDecimalMeta(t).WithSamplePeriod(fiveMin)
+
+	// 12m gap: implicit threshold would be 10m (gap detected), but explicit 20m wins (no gap)
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 200.0, Timestamp: time.Date(2024, 1, 1, 0, 17, 0, 0, time.UTC)}, // 12m gap
+		{Value: 215.0, Timestamp: time.Date(2024, 1, 1, 0, 22, 0, 0, time.UTC)},
+	}
+	result := Result{meta: meta, data: stream.Just(records...)}
+
+	df := NewDeltaFilter(false, 0, false, &twentyMin) // explicit 20m overrides 10m implicit
+	filtered, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	// All deltas computed: 10, 90, 15
+	require.Len(t, collected, 3)
+	require.Equal(t, 10.0, collected[0].Value)
+	require.Equal(t, 90.0, collected[1].Value) // 200-110, NOT skipped
+	require.Equal(t, 15.0, collected[2].Value)
+}
+
+func TestDeltaFilter_ImplicitGap_NoSamplePeriodNoGapDetection(t *testing.T) {
+	ctx := context.Background()
+	meta := cumulativeDecimalMeta(t) // no samplePeriod, no maxGap
+
+	// Large gap, but no gap detection
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 200.0, Timestamp: time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC)}, // 55m gap
+		{Value: 215.0, Timestamp: time.Date(2024, 1, 1, 1, 5, 0, 0, time.UTC)},
+	}
+	result := Result{meta: meta, data: stream.Just(records...)}
+
+	df := NewDeltaFilter(false, 0, false, nil)
+	filtered, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	// All deltas computed (no gap detection): 10, 90, 15
+	require.Len(t, collected, 3)
+}
+
+func TestDeltaFilter_ImplicitGap_NonNegativePath(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	meta := cumulativeDecimalMeta(t).WithSamplePeriod(fiveMin)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 200.0, Timestamp: time.Date(2024, 1, 1, 0, 17, 0, 0, time.UTC)}, // 12m gap
+		{Value: 215.0, Timestamp: time.Date(2024, 1, 1, 0, 22, 0, 0, time.UTC)},
+	}
+	result := Result{meta: meta, data: stream.Just(records...)}
+
+	df := NewDeltaFilter(true, 0, false, nil) // nonNegative=true path
+	filtered, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	// Gap detected in nonNegative path too: 10, (skip), 15
+	require.Len(t, collected, 2)
+	require.Equal(t, 10.0, collected[0].Value)
+	require.Equal(t, 15.0, collected[1].Value)
+}
+
+// --- RateFilter validation ---
+
+func TestRateFilter_RejectsRateInput(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("rate_field", tsquery.DataTypeDecimal, tsquery.MetricKindRate, true, "", nil)
+	require.NoError(t, err)
+	result := Result{meta: *fm, data: simpleStream(1, 2, 3)}
+
+	rf := NewRateFilter("", 1, false, 0, false, nil)
+	_, err = rf.Filter(ctx, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already a rate")
+}
+
+func TestRateFilter_AcceptsGaugeInput(t *testing.T) {
+	ctx := context.Background()
+	meta := gaugeDecimalMeta(t)
+	result := Result{meta: meta, data: simpleStream(20, 22)}
+
+	rf := NewRateFilter("", 1, false, 0, false, nil)
+	filtered, err := rf.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindRate, filtered.Meta().MetricKind())
+}
+
+func TestRateFilter_AcceptsDeltaInput(t *testing.T) {
+	ctx := context.Background()
+	meta := deltaDecimalMeta(t)
+	result := Result{meta: meta, data: simpleStream(10, 15)}
+
+	rf := NewRateFilter("", 1, false, 0, false, nil)
+	filtered, err := rf.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindRate, filtered.Meta().MetricKind())
+}
+
+func TestRateFilter_ImplicitGapFromSamplePeriod(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	meta := cumulativeDecimalMeta(t).WithSamplePeriod(fiveMin)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 160.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 500.0, Timestamp: time.Date(2024, 1, 1, 0, 17, 0, 0, time.UTC)}, // 12m gap
+		{Value: 560.0, Timestamp: time.Date(2024, 1, 1, 0, 22, 0, 0, time.UTC)},
+	}
+	result := Result{meta: meta, data: stream.Just(records...)}
+
+	rf := NewRateFilter("", 1, false, 0, false, nil) // no explicit maxGap
+	filtered, err := rf.Filter(ctx, result)
+	require.NoError(t, err)
+
+	collected := filtered.Data().MustCollect()
+	// First rate: (160-100)/300s, gap skipped, third rate: (560-500)/300s
+	require.Len(t, collected, 2)
+}
+
+// --- Selector kind validation ---
+
+func TestSelectorFieldValue_KindMerge_BothDelta(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+	falseField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	valueMeta, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindDelta, valueMeta.MetricKind)
+}
+
+func TestSelectorFieldValue_KindMerge_BothGauge(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindGauge), 5.0)
+	falseField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindGauge), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	valueMeta, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindGauge, valueMeta.MetricKind)
+}
+
+func TestSelectorFieldValue_KindMerge_DeltaAndUnset(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+	// Unset kind (empty string) — like a constant
+	unsetMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+	falseField := NewConstantFieldValue(unsetMeta, 0.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	valueMeta, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindDelta, valueMeta.MetricKind, "unset is transparent, delta wins")
+}
+
+func TestSelectorFieldValue_KindMerge_UnsetAndDelta(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	unsetMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+	trueField := NewConstantFieldValue(unsetMeta, 0.0)
+	falseField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	valueMeta, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindDelta, valueMeta.MetricKind, "symmetric: unset is transparent regardless of position")
+}
+
+func TestSelectorFieldValue_KindMerge_BothUnset(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	unsetMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+	trueField := NewConstantFieldValue(unsetMeta, 5.0)
+	falseField := NewConstantFieldValue(unsetMeta, 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	valueMeta, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKind(""), valueMeta.MetricKind, "both unset → output unset")
+}
+
+func TestSelectorFieldValue_KindMerge_DeltaVsCumulative_Error(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+	falseField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindCumulative), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	_, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "matching metric kinds")
+}
+
+func TestSelectorFieldValue_KindMerge_RateVsDelta_Error(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindRate), 5.0)
+	falseField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	_, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "matching metric kinds")
+}
+
+func TestSelectorFieldValue_KindMerge_CumulativeVsRate_Error(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindCumulative), 5.0)
+	falseField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindRate), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	_, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "matching metric kinds")
+}
+
+func TestSelectorFieldValue_KindMerge_DeltaVsExplicitGauge_Error(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+	falseField := NewConstantFieldValue(valueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindGauge), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	_, _, err := sel.Execute(ctx, dummyFieldMeta())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "matching metric kinds")
+}
+
+// --- Golden integration tests ---
+
+func TestGolden_CumulativeToDeltaToAligner(t *testing.T) {
+	ctx := context.Background()
+
+	// Cumulative energy counter reporting every 5 minutes
+	fm, err := tsquery.NewFieldMetaFull("lifetimeEnergy", tsquery.DataTypeDecimal, tsquery.MetricKindCumulative, true, "kWh", nil)
+	require.NoError(t, err)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		{Value: 125.0, Timestamp: time.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC)},
+		{Value: 140.0, Timestamp: time.Date(2024, 1, 1, 0, 15, 0, 0, time.UTC)},
+		{Value: 155.0, Timestamp: time.Date(2024, 1, 1, 0, 20, 0, 0, time.UTC)},
+		{Value: 170.0, Timestamp: time.Date(2024, 1, 1, 0, 25, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	// Step 1: DeltaFilter (cumulative → delta)
+	df := NewDeltaFilter(false, 0, false, nil)
+	deltaResult, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindDelta, deltaResult.Meta().MetricKind())
+
+	// Step 2: AlignerFilter(15m, no explicit reduction) — should auto-select Sum
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC))
+	alignedResult, err := af.Filter(ctx, deltaResult)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindDelta, alignedResult.Meta().MetricKind())
+
+	collected := alignedResult.Data().MustCollect()
+	require.Len(t, collected, 2)
+
+	// Deltas: 10, 15, 15, 15, 15
+	// Bucket [0:00-0:15): deltas at 0:05(10), 0:10(15) = 25
+	// Bucket [0:15-0:30): deltas at 0:15(15), 0:20(15), 0:25(15) = 45
+	require.Equal(t, 25.0, collected[0].Value)
+	require.Equal(t, 45.0, collected[1].Value)
+}
+
+func TestGolden_GaugeThroughAligner_Unchanged(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("temp", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "celsius", nil)
+	require.NoError(t, err)
+
+	// Two values in the same bucket — interpolation should still work
+	records := []timeseries.TsRecord[any]{
+		{Value: 20.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 25.0, Timestamp: time.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC))
+	filtered, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKindGauge, filtered.Meta().MetricKind())
+
+	// Gauge uses interpolation path, not Sum
+	collected := filtered.Data().MustCollect()
+	require.Len(t, collected, 1)
+	require.Equal(t, 20.0, collected[0].Value) // first item smudged to bucket start
+}
+
+func TestGolden_GaugeToDeltaFilter_Error(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("temp", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "celsius", nil)
+	require.NoError(t, err)
+	result := Result{meta: *fm, data: simpleStream(20, 22, 19)}
+
+	df := NewDeltaFilter(false, 0, false, nil)
+	_, err = df.Filter(ctx, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gauge")
+}
+
+func TestGolden_PipelineWithGap(t *testing.T) {
+	ctx := context.Background()
+	fiveMin := 5 * time.Minute
+	fm, err := tsquery.NewFieldMetaFull("lifetimeEnergy", tsquery.DataTypeDecimal, tsquery.MetricKindCumulative, true, "kWh", nil)
+	require.NoError(t, err)
+	*fm = fm.WithSamplePeriod(fiveMin)
+
+	// Counter with a 12m gap between 0:05 and 0:17
+	records := []timeseries.TsRecord[any]{
+		{Value: 100.0, Timestamp: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: 110.0, Timestamp: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC)},
+		// gap: 12 minutes > 10m threshold
+		{Value: 200.0, Timestamp: time.Date(2024, 1, 1, 0, 17, 0, 0, time.UTC)},
+		{Value: 215.0, Timestamp: time.Date(2024, 1, 1, 0, 22, 0, 0, time.UTC)},
+		{Value: 230.0, Timestamp: time.Date(2024, 1, 1, 0, 27, 0, 0, time.UTC)},
+	}
+	result := Result{meta: *fm, data: stream.Just(records...)}
+
+	// DeltaFilter with implicit gap from samplePeriod
+	df := NewDeltaFilter(false, 0, false, nil)
+	deltaResult, err := df.Filter(ctx, result)
+	require.NoError(t, err)
+
+	// Aligner(15m) with auto-Sum
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(15*time.Minute, time.UTC))
+	alignedResult, err := af.Filter(ctx, deltaResult)
+	require.NoError(t, err)
+
+	collected := alignedResult.Data().MustCollect()
+	// Deltas: 10 @ 0:05, (gap skip), 15 @ 0:22, 15 @ 0:27
+	// Bucket [0:00-0:15): delta 10 = 10
+	// Bucket [0:15-0:30): deltas 15 + 15 = 30
+	require.Len(t, collected, 2)
+	require.Equal(t, 10.0, collected[0].Value)
+	require.Equal(t, 30.0, collected[1].Value)
+}
+
+func TestGolden_RateOfRate_Error(t *testing.T) {
+	ctx := context.Background()
+	fm, err := tsquery.NewFieldMetaFull("rate_field", tsquery.DataTypeDecimal, tsquery.MetricKindRate, true, "", nil)
+	require.NoError(t, err)
+	result := Result{meta: *fm, data: simpleStream(1, 2, 3)}
+
+	rf := NewRateFilter("", 1, false, 0, false, nil)
+	_, err = rf.Filter(ctx, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already a rate")
+}

--- a/utils/timeseries/tsquery/datasource/metric_kind_propagation_test.go
+++ b/utils/timeseries/tsquery/datasource/metric_kind_propagation_test.go
@@ -60,17 +60,16 @@ func TestDeltaFilter_OutputKindIsDelta(t *testing.T) {
 	require.Equal(t, "kWh", filtered.Meta().Unit())
 }
 
-func TestDeltaFilter_OutputKindIsDelta_FromGauge(t *testing.T) {
-	// In Phase 1, DeltaFilter accepts any kind (no validation yet)
+func TestDeltaFilter_RejectsGaugeInput(t *testing.T) {
 	ctx := context.Background()
 	meta := gaugeDecimalMeta(t)
 
 	result := Result{meta: meta, data: simpleStream(20, 22, 19)}
 
 	df := NewDeltaFilter(false, 0, false, nil)
-	filtered, err := df.Filter(ctx, result)
-	require.NoError(t, err)
-	require.Equal(t, tsquery.MetricKindDelta, filtered.Meta().MetricKind())
+	_, err := df.Filter(ctx, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gauge")
 }
 
 func TestRateFilter_OutputKindIsRate(t *testing.T) {
@@ -87,10 +86,31 @@ func TestRateFilter_OutputKindIsRate(t *testing.T) {
 	require.Equal(t, tsquery.DataTypeDecimal, filtered.Meta().DataType())
 }
 
-func TestAlignerFilter_PreservesKind(t *testing.T) {
+func TestAlignerFilter_PreservesKind_InterpolationPath(t *testing.T) {
 	ctx := context.Background()
 
-	for _, kind := range []tsquery.MetricKind{tsquery.MetricKindGauge, tsquery.MetricKindDelta, tsquery.MetricKindCumulative, tsquery.MetricKindRate} {
+	// Gauge and Rate use the interpolation path (no auto bucket reduction)
+	for _, kind := range []tsquery.MetricKind{tsquery.MetricKindGauge, tsquery.MetricKindRate} {
+		t.Run(string(kind), func(t *testing.T) {
+			fm, err := tsquery.NewFieldMetaFull("field", tsquery.DataTypeDecimal, kind, true, "", nil)
+			require.NoError(t, err)
+
+			result := Result{meta: *fm, data: simpleStream(1, 2, 3)}
+
+			af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(10*time.Minute, time.UTC))
+			filtered, err := af.Filter(ctx, result)
+			require.NoError(t, err)
+			require.Equal(t, kind, filtered.Meta().MetricKind())
+		})
+	}
+}
+
+func TestAlignerFilter_PreservesKind_AutoReductionPath(t *testing.T) {
+	ctx := context.Background()
+
+	// Delta and Cumulative auto-select bucket reductions (Sum and Last respectively)
+	// but the output kind should still match the input kind
+	for _, kind := range []tsquery.MetricKind{tsquery.MetricKindDelta, tsquery.MetricKindCumulative} {
 		t.Run(string(kind), func(t *testing.T) {
 			fm, err := tsquery.NewFieldMetaFull("field", tsquery.DataTypeDecimal, kind, true, "", nil)
 			require.NoError(t, err)
@@ -215,6 +235,19 @@ func TestRefFieldValue_ExtractsMetricKind(t *testing.T) {
 	require.Equal(t, tsquery.MetricKindCumulative, valueMeta.MetricKind)
 }
 
+func TestRefFieldValue_UnsetKindPropagatesEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	// NewFieldMeta does not set metricKind — raw kind should be "" (not gauge)
+	sourceMeta, err := tsquery.NewFieldMeta("temp", tsquery.DataTypeDecimal, true)
+	require.NoError(t, err)
+
+	ref := NewRefFieldValue()
+	valueMeta, _, err := ref.Execute(ctx, *sourceMeta)
+	require.NoError(t, err)
+	require.Equal(t, tsquery.MetricKind(""), valueMeta.MetricKind, "unset kind should propagate as empty string, not gauge")
+}
+
 func TestCastFieldValue_PropagatesKind(t *testing.T) {
 	ctx := context.Background()
 
@@ -285,10 +318,10 @@ func TestNumericExpression_OpsDontChangeKindRule(t *testing.T) {
 	require.Equal(t, tsquery.MetricKindCumulative, valueMeta.MetricKind)
 }
 
-// TestSelectorFieldValue_PropagatesKindFromTrueBranch documents the Phase 1 rule:
-// selector propagates MetricKind from the true branch.
-// Phase 2 will add strict validation that both branches must match.
-func TestSelectorFieldValue_PropagatesKindFromTrueBranch(t *testing.T) {
+// TestSelectorFieldValue_MatchingKinds verifies that when both branches have the
+// same kind, the selector output carries that kind. Phase 2 added a gauge-transparent
+// merge rule — see metric_kind_phase2_test.go for mismatch and transparent cases.
+func TestSelectorFieldValue_MatchingKinds(t *testing.T) {
 	ctx := context.Background()
 
 	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
@@ -349,20 +382,22 @@ func TestRateFilter_ClearsSamplePeriod(t *testing.T) {
 	require.Equal(t, tsquery.MetricKindRate, filtered.Meta().MetricKind())
 }
 
-func TestAlignerFilter_PreservesSamplePeriod(t *testing.T) {
+func TestAlignerFilter_OutputSamplePeriodFromAlignmentPeriod(t *testing.T) {
 	ctx := context.Background()
 	fiveMin := 5 * time.Minute
+	tenMin := 10 * time.Minute
 	fm, err := tsquery.NewFieldMetaFull("energy", tsquery.DataTypeDecimal, tsquery.MetricKindDelta, true, "kWh", nil)
 	require.NoError(t, err)
 	*fm = fm.WithSamplePeriod(fiveMin)
 
 	result := Result{meta: *fm, data: simpleStream(10, 15, 20)}
 
-	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(10*time.Minute, time.UTC))
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(tenMin, time.UTC))
 	filtered, err := af.Filter(ctx, result)
 	require.NoError(t, err)
+	// Output samplePeriod should be the alignment period (10m), not the input (5m)
 	require.NotNil(t, filtered.Meta().SamplePeriod())
-	require.Equal(t, fiveMin, *filtered.Meta().SamplePeriod())
+	require.Equal(t, tenMin, *filtered.Meta().SamplePeriod())
 }
 
 func TestCastFieldValue_PropagatesSamplePeriod(t *testing.T) {

--- a/utils/timeseries/tsquery/datasource/rate_filter.go
+++ b/utils/timeseries/tsquery/datasource/rate_filter.go
@@ -46,6 +46,9 @@ func (rf RateFilter) Filter(_ context.Context, result Result) (Result, error) {
 			"rate filter can only be applied to required fields (no nils allowed)",
 		)
 	}
+	if result.meta.MetricKind() == tsquery.MetricKindRate {
+		return util.DefaultValue[Result](), fmt.Errorf("rate filter cannot be applied to data that is already a rate")
+	}
 
 	// samplePeriod intentionally not set — a computed rate has no meaningful sample period
 	newMeta, err := tsquery.NewFieldMetaFull(
@@ -74,6 +77,15 @@ func (rf RateFilter) Filter(_ context.Context, result Result) (Result, error) {
 		}
 	}
 
+	// Implicit gap threshold: when no explicit maxGapDuration, use 2×samplePeriod
+	effectiveMaxGap := rf.optMaxGapDuration
+	if effectiveMaxGap == nil {
+		if sp := result.meta.SamplePeriod(); sp != nil {
+			defaultGap := *sp * 2
+			effectiveMaxGap = &defaultGap
+		}
+	}
+
 	var prevItem *timeseries.TsRecord[any]
 	return Result{
 		meta: *newMeta,
@@ -87,7 +99,7 @@ func (rf RateFilter) Filter(_ context.Context, result Result) (Result, error) {
 				}
 
 				// Gap detection: if gap exceeds threshold, treat as new baseline
-				if rf.optMaxGapDuration != nil && item.Timestamp.Sub(prevItem.Timestamp) > *rf.optMaxGapDuration {
+				if effectiveMaxGap != nil && item.Timestamp.Sub(prevItem.Timestamp) > *effectiveMaxGap {
 					prevItem = &item
 					return nil, nil
 				}

--- a/utils/timeseries/tsquery/datasource/ref_field_value.go
+++ b/utils/timeseries/tsquery/datasource/ref_field_value.go
@@ -23,7 +23,7 @@ func (rf RefFieldValue) Execute(ctx context.Context, fieldMeta tsquery.FieldMeta
 
 	return tsquery.ValueMeta{
 		DataType:     fieldMeta.DataType(),
-		MetricKind:   fieldMeta.MetricKind(),
+		MetricKind:   fieldMeta.RawMetricKind(),
 		SamplePeriod: fieldMeta.SamplePeriod(),
 		Unit:         fieldMeta.Unit(),
 		Required:   fieldMeta.Required(),

--- a/utils/timeseries/tsquery/datasource/selector_field_value.go
+++ b/utils/timeseries/tsquery/datasource/selector_field_value.go
@@ -88,10 +88,26 @@ func (cf SelectorFieldValue) Execute(ctx context.Context, fieldMeta tsquery.Fiel
 		)
 	}
 
+	// Validate metric kind: unset ("") is transparent, explicit kinds must match
+	trueKind := trueMeta.MetricKind
+	falseKind := falseMeta.MetricKind
+	if trueKind != falseKind {
+		if trueKind != "" && falseKind != "" {
+			return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
+				"selector requires matching metric kinds: true=%s, false=%s",
+				trueKind, falseKind,
+			)
+		}
+	}
+	outputKind := trueKind
+	if trueKind == "" {
+		outputKind = falseKind
+	}
+
 	// Create field metadata
 	fvm := tsquery.ValueMeta{
 		DataType:     trueType,
-		MetricKind:   trueMeta.MetricKind,
+		MetricKind:   outputKind,
 		SamplePeriod: trueMeta.SamplePeriod,
 		Unit:         trueMeta.Unit,
 		Required:   trueMeta.Required,

--- a/utils/timeseries/tsquery/e2e_aggregation_test.go
+++ b/utils/timeseries/tsquery/e2e_aggregation_test.go
@@ -334,7 +334,7 @@ func TestAggregation_WithFilters(t *testing.T) {
 	}
 	// Values: 10, 20, 30, 40
 	values := []any{int64(10), int64(20), int64(30), int64(40)}
-	rawDS := createDatasource(t, "energy", tsquery.DataTypeInteger, true, "kWh", timestamps, values)
+	rawDS := createCumulativeDatasource(t, "energy", tsquery.DataTypeInteger, true, "kWh", timestamps, values)
 
 	// Apply a delta filter: delta produces 3 values: 10, 10, 10
 	filteredDS := datasource.NewFilteredDataSource(rawDS, datasource.NewDeltaFilter(false, 0, false, nil))

--- a/utils/timeseries/tsquery/e2e_delta_filter_test.go
+++ b/utils/timeseries/tsquery/e2e_delta_filter_test.go
@@ -22,7 +22,7 @@ func TestDeltaFilter_Decimal(t *testing.T) {
 	}
 
 	// Cumulative energy: 100, 150, 180, 250 kWh
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 150.0, 180.0, 250.0})
 
 	// Apply delta filter
@@ -65,7 +65,7 @@ func TestDeltaFilter_Integer(t *testing.T) {
 	}
 
 	// Cumulative counter: 1000, 1042, 1100
-	ds := createDatasource(t, "Counter", tsquery.DataTypeInteger, true, "count",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeInteger, true, "count",
 		timestamps, []any{int64(1000), int64(1042), int64(1100)})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, nil))
@@ -95,8 +95,9 @@ func TestDeltaFilter_NegativeDelta(t *testing.T) {
 		baseTime.Add(2 * time.Hour),
 	}
 
-	// Values go down: 100, 80, 50
-	ds := createDatasource(t, "Temperature", tsquery.DataTypeDecimal, true, "celsius",
+	// Cumulative counter that decreases (e.g., counter reset without nonNegative)
+	// With nonNegative=false, negative deltas are computed as-is
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "count",
 		timestamps, []any{100.0, 80.0, 50.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, nil))
@@ -114,7 +115,7 @@ func TestDeltaFilter_NegativeDelta(t *testing.T) {
 func TestDeltaFilter_EmptyStream(t *testing.T) {
 	ctx := context.Background()
 
-	fieldMeta, err := tsquery.NewFieldMetaWithCustomData("Empty", tsquery.DataTypeDecimal, true, "", nil)
+	fieldMeta, err := tsquery.NewFieldMetaFull("Empty", tsquery.DataTypeDecimal, tsquery.MetricKindCumulative, true, "", nil)
 	require.NoError(t, err)
 
 	ds, err := datasource.NewStaticDatasource(*fieldMeta, stream.Empty[timeseries.TsRecord[any]]())
@@ -133,7 +134,7 @@ func TestDeltaFilter_SingleItem(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	ds := createDatasource(t, "Single", tsquery.DataTypeDecimal, true, "",
+	ds := createCumulativeDatasource(t, "Single", tsquery.DataTypeDecimal, true, "",
 		[]time.Time{baseTime}, []any{42.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, nil))
@@ -150,7 +151,7 @@ func TestDeltaFilter_ErrorOnStringDataType(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	ds := createDatasource(t, "StringField", tsquery.DataTypeString, true, "",
+	ds := createCumulativeDatasource(t, "StringField", tsquery.DataTypeString, true, "",
 		[]time.Time{baseTime}, []any{"hello"})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, nil))
@@ -164,7 +165,7 @@ func TestDeltaFilter_ErrorOnBooleanDataType(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	ds := createDatasource(t, "BoolField", tsquery.DataTypeBoolean, true, "",
+	ds := createCumulativeDatasource(t, "BoolField", tsquery.DataTypeBoolean, true, "",
 		[]time.Time{baseTime}, []any{true})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, nil))
@@ -179,7 +180,7 @@ func TestDeltaFilter_ErrorOnOptionalField(t *testing.T) {
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	// required=false
-	ds := createDatasource(t, "OptionalField", tsquery.DataTypeDecimal, false, "",
+	ds := createCumulativeDatasource(t, "OptionalField", tsquery.DataTypeDecimal, false, "",
 		[]time.Time{baseTime}, []any{42.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, nil))
@@ -194,7 +195,7 @@ func TestDeltaFilter_PreservesUnit(t *testing.T) {
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	timestamps := []time.Time{baseTime, baseTime.Add(1 * time.Hour)}
 
-	ds := createDatasource(t, "Energy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Energy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 150.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, nil))
@@ -218,7 +219,7 @@ func TestDeltaFilter_NonNegative_ResetToZero(t *testing.T) {
 	}
 
 	// Counter resets to zero: 100, 150, 0, 30
-	ds := createDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 150.0, 0.0, 30.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, false, nil))
@@ -245,7 +246,7 @@ func TestDeltaFilter_NonNegative_ResetToNonZero(t *testing.T) {
 	}
 
 	// Counter resets to non-zero: 100, 150, 50, 80
-	ds := createDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 150.0, 50.0, 80.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, false, nil))
@@ -272,7 +273,7 @@ func TestDeltaFilter_NonNegative_NegativeValueDropped(t *testing.T) {
 	}
 
 	// Negative value at index 2: 100, 150, -5, 80
-	ds := createDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 150.0, -5.0, 80.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, false, nil))
@@ -298,7 +299,7 @@ func TestDeltaFilter_NonNegative_NormalIncrease(t *testing.T) {
 	}
 
 	// Normal increasing values: 100, 150, 200
-	ds := createDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 150.0, 200.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, false, nil))
@@ -324,7 +325,7 @@ func TestDeltaFilter_NonNegative_Integer(t *testing.T) {
 	}
 
 	// Integer counter with reset: 1000, 1050, 200, 250
-	ds := createDatasource(t, "Counter", tsquery.DataTypeInteger, true, "count",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeInteger, true, "count",
 		timestamps, []any{int64(1000), int64(1050), int64(200), int64(250)})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, false, nil))
@@ -350,7 +351,7 @@ func TestDeltaFilter_MaxCounterValue_Wraparound(t *testing.T) {
 	}
 
 	// Counter wraps around max 1000: 900, 950, 100
-	ds := createDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{900.0, 950.0, 100.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 1000, false, nil))
@@ -375,7 +376,7 @@ func TestDeltaFilter_MaxCounterValue_NormalIncrease(t *testing.T) {
 	}
 
 	// Normal increase with maxCounterValue set: 100, 200, 300
-	ds := createDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 200.0, 300.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 1000, false, nil))
@@ -403,7 +404,7 @@ func TestDeltaFilter_EmitOnReset_ResetToNonZero(t *testing.T) {
 	}
 
 	// Counter resets to non-zero: 100, 150, 50, 80
-	ds := createDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 150.0, 50.0, 80.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, true, nil))
@@ -430,7 +431,7 @@ func TestDeltaFilter_EmitOnReset_Integer(t *testing.T) {
 	}
 
 	// Integer counter with reset: 1000, 1050, 200, 250
-	ds := createDatasource(t, "Counter", tsquery.DataTypeInteger, true, "count",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeInteger, true, "count",
 		timestamps, []any{int64(1000), int64(1050), int64(200), int64(250)})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, true, nil))
@@ -461,7 +462,7 @@ func TestDeltaFilter_NonNegative_GlitchClampedToZero(t *testing.T) {
 
 	// Simulates energy meter glitch: cumulative value dips briefly then recovers
 	// 12800000, 12800100, 12799580 (glitch!), 12800200, 12800350
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "Wh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "Wh",
 		timestamps, []any{12800000.0, 12800100.0, 12799580.0, 12800200.0, 12800350.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, false, nil))
@@ -490,7 +491,7 @@ func TestDeltaFilter_EmitOnReset_GlitchCausesSpike(t *testing.T) {
 
 	// Same glitch scenario but with emitOnReset=true — shows why clamp is better
 	// 12800000, 12800100, 12799580 (glitch!), 12800200
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "Wh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "Wh",
 		timestamps, []any{12800000.0, 12800100.0, 12799580.0, 12800200.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, true, nil))
@@ -515,8 +516,8 @@ func TestDeltaFilter_NonNegative_False_StillAllowsNegative(t *testing.T) {
 		baseTime.Add(2 * time.Hour),
 	}
 
-	// Decreasing values with nonNegative=false: old behavior preserved
-	ds := createDatasource(t, "Temperature", tsquery.DataTypeDecimal, true, "celsius",
+	// Decreasing cumulative counter with nonNegative=false: negative deltas allowed
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "count",
 		timestamps, []any{100.0, 80.0, 50.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, nil))
@@ -545,7 +546,7 @@ func TestDeltaFilter_MaxGapDuration_DropsLargeGap(t *testing.T) {
 		baseTime.Add(11 * time.Hour),
 	}
 
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 200.0, 500.0, 520.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, durationPtr(2*time.Hour)))
@@ -576,7 +577,7 @@ func TestDeltaFilter_MaxGapDuration_NormalSpacingPasses(t *testing.T) {
 		baseTime.Add(3 * time.Hour),
 	}
 
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 200.0, 350.0, 500.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, durationPtr(2*time.Hour)))
@@ -600,7 +601,7 @@ func TestDeltaFilter_MaxGapDuration_ExactBoundaryAllowed(t *testing.T) {
 		baseTime.Add(2 * time.Hour), // gap exactly equals maxGap
 	}
 
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 300.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, durationPtr(2*time.Hour)))
@@ -624,7 +625,7 @@ func TestDeltaFilter_MaxGapDuration_ConsecutiveGaps(t *testing.T) {
 		baseTime.Add(21 * time.Hour), // 1h gap
 	}
 
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 500.0, 900.0, 920.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, durationPtr(2*time.Hour)))
@@ -649,7 +650,7 @@ func TestDeltaFilter_MaxGapDuration_BaselineReset(t *testing.T) {
 		baseTime.Add(11 * time.Hour),
 	}
 
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 200.0, 500.0, 520.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, durationPtr(2*time.Hour)))
@@ -674,7 +675,7 @@ func TestDeltaFilter_MaxGapDuration_NilDisabled(t *testing.T) {
 		baseTime.Add(11 * time.Hour),
 	}
 
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 200.0, 500.0, 520.0})
 
 	// nil maxGapDuration = no gap detection (backwards compatible)
@@ -702,7 +703,7 @@ func TestDeltaFilter_MaxGapDuration_WithNonNegative(t *testing.T) {
 		baseTime.Add(11 * time.Hour),
 	}
 
-	ds := createDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Counter", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 200.0, 50.0, 500.0, 520.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(true, 0, false, durationPtr(2*time.Hour)))
@@ -726,7 +727,7 @@ func TestDeltaFilter_MaxGapDuration_SingleItem(t *testing.T) {
 	ctx := context.Background()
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		[]time.Time{baseTime}, []any{100.0})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, durationPtr(2*time.Hour)))
@@ -741,7 +742,7 @@ func TestDeltaFilter_MaxGapDuration_SingleItem(t *testing.T) {
 func TestDeltaFilter_MaxGapDuration_EmptyStream(t *testing.T) {
 	ctx := context.Background()
 
-	ds := createDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "LifetimeEnergy", tsquery.DataTypeDecimal, true, "kWh",
 		[]time.Time{}, []any{})
 
 	filtered := datasource.NewFilteredDataSource(ds, datasource.NewDeltaFilter(false, 0, false, durationPtr(2*time.Hour)))

--- a/utils/timeseries/tsquery/e2e_filtered_multi_datasource_test.go
+++ b/utils/timeseries/tsquery/e2e_filtered_multi_datasource_test.go
@@ -20,7 +20,7 @@ func TestFilteredMultiDatasource_DeltaNonNegative_ThenReduce(t *testing.T) {
 
 	// Counter1: cumulative counter that resets at hour 3
 	// 100 -> 200 -> 300 -> 0 (reset) -> 100
-	counter1 := createDatasource(t, "Counter1", tsquery.DataTypeInteger, true, "bytes",
+	counter1 := createCumulativeDatasource(t, "Counter1", tsquery.DataTypeInteger, true, "bytes",
 		[]time.Time{
 			baseTime,
 			baseTime.Add(1 * time.Hour),
@@ -33,7 +33,7 @@ func TestFilteredMultiDatasource_DeltaNonNegative_ThenReduce(t *testing.T) {
 
 	// Counter2: cumulative counter, no resets
 	// 10 -> 30 -> 60 -> 100 -> 150
-	counter2 := createDatasource(t, "Counter2", tsquery.DataTypeInteger, true, "bytes",
+	counter2 := createCumulativeDatasource(t, "Counter2", tsquery.DataTypeInteger, true, "bytes",
 		[]time.Time{
 			baseTime,
 			baseTime.Add(1 * time.Hour),

--- a/utils/timeseries/tsquery/e2e_reduction_datasource_test.go
+++ b/utils/timeseries/tsquery/e2e_reduction_datasource_test.go
@@ -15,10 +15,18 @@ func alignerFilterPtr(af datasource.AlignerFilter) *datasource.AlignerFilter { r
 
 // Helper function to create a single-value datasource from scalar values
 func createDatasource(t *testing.T, urn string, dataType tsquery.DataType, required bool, unit string, timestamps []time.Time, values []any) datasource.DataSource {
+	return createDatasourceWithKind(t, urn, dataType, "", required, unit, timestamps, values)
+}
+
+func createCumulativeDatasource(t *testing.T, urn string, dataType tsquery.DataType, required bool, unit string, timestamps []time.Time, values []any) datasource.DataSource {
+	return createDatasourceWithKind(t, urn, dataType, tsquery.MetricKindCumulative, required, unit, timestamps, values)
+}
+
+func createDatasourceWithKind(t *testing.T, urn string, dataType tsquery.DataType, kind tsquery.MetricKind, required bool, unit string, timestamps []time.Time, values []any) datasource.DataSource {
 	require.Equal(t, len(timestamps), len(values), "timestamps and values must have same length")
 
 	// Create field metadata
-	fieldMeta, err := tsquery.NewFieldMetaWithCustomData(urn, dataType, required, unit, nil)
+	fieldMeta, err := tsquery.NewFieldMetaFull(urn, dataType, kind, required, unit, nil)
 	require.NoError(t, err)
 
 	// Create records

--- a/utils/timeseries/tsquery/e2e_time_shift_filter_test.go
+++ b/utils/timeseries/tsquery/e2e_time_shift_filter_test.go
@@ -209,7 +209,7 @@ func TestTimeShiftFilter_CompositionWithDelta(t *testing.T) {
 	}
 
 	// Cumulative energy readings at end-of-hour
-	ds := createDatasource(t, "Energy", tsquery.DataTypeDecimal, true, "kWh",
+	ds := createCumulativeDatasource(t, "Energy", tsquery.DataTypeDecimal, true, "kWh",
 		timestamps, []any{100.0, 250.0, 400.0})
 
 	// First apply delta, then time shift

--- a/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_test.go
+++ b/utils/timeseries/tsquery/queryopenapi/cmd/tsquery-parser-codegen/openapi_parser_test.go
@@ -1488,10 +1488,11 @@ func TestParseFilter_DeltaFilter(t *testing.T) {
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "LifetimeEnergy",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true, // Must be required for delta filter
-			Unit:     "kWh",
+			Uri:        "LifetimeEnergy",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true, // Must be required for delta filter
+			Unit:       "kWh",
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -1548,10 +1549,11 @@ func TestParseFilter_DeltaFilter_NonNegative(t *testing.T) {
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "LifetimeEnergy",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
-			Unit:     "kWh",
+			Uri:        "LifetimeEnergy",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			Unit:       "kWh",
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -1601,10 +1603,11 @@ func TestParseFilter_DeltaFilter_MaxCounterValue(t *testing.T) {
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "Counter",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
-			Unit:     "kWh",
+			Uri:        "Counter",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			Unit:       "kWh",
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 900.0},
@@ -1647,16 +1650,17 @@ func TestParseFilter_DeltaFilter_MaxCounterValue(t *testing.T) {
 	assert.Equal(t, 150.0, records[1].Value) // wrap: (1000 - 950) + 100 = 150
 }
 
-func TestParseFilter_DeltaFilter_BackwardCompatible(t *testing.T) {
+func TestParseFilter_DeltaFilter_DefaultOptions(t *testing.T) {
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "Temperature",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
-			Unit:     "celsius",
+			Uri:        "Counter",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			Unit:       "count",
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -1822,13 +1826,14 @@ func TestParseFilter_RateFilter_MaxCounterValueWithoutNonNegative_Error(t *testi
 func TestParseFilter_DeltaFilter_NegativeDelta(t *testing.T) {
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	// Create a static datasource where values decrease
+	// Create a cumulative counter where values decrease (counter reset without nonNegative)
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "Temperature",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
+			Uri:        "Counter",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -2387,9 +2392,10 @@ func TestParseFilteredMultiDatasource(t *testing.T) {
 	staticDs1 := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "counter1",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
+			Uri:        "counter1",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -2400,9 +2406,10 @@ func TestParseFilteredMultiDatasource(t *testing.T) {
 	staticDs2 := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "counter2",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
+			Uri:        "counter2",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 10.0},

--- a/utils/timeseries/tsquery/queryopenapi/openapi_parser_test.go
+++ b/utils/timeseries/tsquery/queryopenapi/openapi_parser_test.go
@@ -1486,10 +1486,11 @@ func TestParseFilter_DeltaFilter(t *testing.T) {
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "LifetimeEnergy",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true, // Must be required for delta filter
-			Unit:     "kWh",
+			Uri:        "LifetimeEnergy",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true, // Must be required for delta filter
+			Unit:       "kWh",
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -1546,10 +1547,11 @@ func TestParseFilter_DeltaFilter_NonNegative(t *testing.T) {
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "LifetimeEnergy",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
-			Unit:     "kWh",
+			Uri:        "LifetimeEnergy",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			Unit:       "kWh",
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -1599,10 +1601,11 @@ func TestParseFilter_DeltaFilter_MaxCounterValue(t *testing.T) {
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "Counter",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
-			Unit:     "kWh",
+			Uri:        "Counter",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			Unit:       "kWh",
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 900.0},
@@ -1645,16 +1648,17 @@ func TestParseFilter_DeltaFilter_MaxCounterValue(t *testing.T) {
 	assert.Equal(t, 150.0, records[1].Value) // wrap: (1000 - 950) + 100 = 150
 }
 
-func TestParseFilter_DeltaFilter_BackwardCompatible(t *testing.T) {
+func TestParseFilter_DeltaFilter_DefaultOptions(t *testing.T) {
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "Temperature",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
-			Unit:     "celsius",
+			Uri:        "Counter",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			Unit:       "count",
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -1820,13 +1824,14 @@ func TestParseFilter_RateFilter_MaxCounterValueWithoutNonNegative_Error(t *testi
 func TestParseFilter_DeltaFilter_NegativeDelta(t *testing.T) {
 	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	// Create a static datasource where values decrease
+	// Create a cumulative counter where values decrease (counter reset without nonNegative)
 	staticDs := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "Temperature",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
+			Uri:        "Counter",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -2385,9 +2390,10 @@ func TestParseFilteredMultiDatasource(t *testing.T) {
 	staticDs1 := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "counter1",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
+			Uri:        "counter1",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 100.0},
@@ -2398,9 +2404,10 @@ func TestParseFilteredMultiDatasource(t *testing.T) {
 	staticDs2 := ApiStaticQueryDatasource{
 		Type: "static",
 		FieldMeta: ApiQueryFieldMeta{
-			Uri:      "counter2",
-			DataType: tsquery.DataTypeDecimal,
-			Required: true,
+			Uri:        "counter2",
+			DataType:   tsquery.DataTypeDecimal,
+			Required:   true,
+			MetricKind: tsquery.MetricKindCumulative,
 		},
 		Data: []ApiMeasurementValue{
 			{Timestamp: baseTime, Value: 10.0},

--- a/utils/timeseries/tsquery/report/metric_kind_propagation_test.go
+++ b/utils/timeseries/tsquery/report/metric_kind_propagation_test.go
@@ -52,6 +52,23 @@ func TestRefFieldValue_ExtractsMetricKind(t *testing.T) {
 	}
 }
 
+// TestRefFieldValue_UnsetKindPropagatesEmpty verifies that RefFieldValue propagates
+// "" (not gauge) for fields with no explicit metricKind, preserving the unset signal.
+func TestRefFieldValue_UnsetKindPropagatesEmpty(t *testing.T) {
+	ctx := context.Background()
+
+	// NewFieldMeta does not set metricKind — raw kind is ""
+	untaggedMeta, err := tsquery.NewFieldMeta("temp", tsquery.DataTypeDecimal, true)
+	require.NoError(t, err)
+
+	fieldsMeta := []tsquery.FieldMeta{*untaggedMeta}
+
+	ref := NewRefFieldValue("temp")
+	valueMeta, _, err := ref.Execute(ctx, fieldsMeta)
+	require.NoError(t, err)
+	assert.Equal(t, tsquery.MetricKind(""), valueMeta.MetricKind, "unset kind should propagate as empty string, not gauge")
+}
+
 // TestPrepareField_PropagatesKindFromSource verifies that PrepareField carries
 // MetricKind through from the underlying value's ValueMeta into the built FieldMeta.
 func TestPrepareField_PropagatesKindFromSource(t *testing.T) {
@@ -203,4 +220,91 @@ func TestAppendFieldFilter_PropagatesKind(t *testing.T) {
 	assert.Equal(t, tsquery.MetricKindCumulative, filteredResult.FieldsMeta()[0].MetricKind())
 	// Appended field inherits kind from source (via RefFieldValue → ValueMeta → PrepareField)
 	assert.Equal(t, tsquery.MetricKindCumulative, filteredResult.FieldsMeta()[1].MetricKind())
+}
+
+// --- Phase 2: Selector kind merge tests (report side) ---
+
+func reportValueMetaWithKind(dt tsquery.DataType, kind tsquery.MetricKind) tsquery.ValueMeta {
+	return tsquery.ValueMeta{DataType: dt, MetricKind: kind, Required: true}
+}
+
+func TestReportSelectorFieldValue_KindMerge_DeltaAndUnset(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(reportValueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+	unsetMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+	falseField := NewConstantFieldValue(unsetMeta, 0.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	valueMeta, _, err := sel.Execute(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, tsquery.MetricKindDelta, valueMeta.MetricKind, "unset is transparent, delta wins")
+}
+
+func TestReportSelectorFieldValue_KindMerge_UnsetAndDelta(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	unsetMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+	trueField := NewConstantFieldValue(unsetMeta, 0.0)
+	falseField := NewConstantFieldValue(reportValueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	valueMeta, _, err := sel.Execute(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, tsquery.MetricKindDelta, valueMeta.MetricKind, "symmetric: unset is transparent")
+}
+
+func TestReportSelectorFieldValue_KindMerge_BothUnset(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	unsetMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeDecimal, Required: true}
+	trueField := NewConstantFieldValue(unsetMeta, 5.0)
+	falseField := NewConstantFieldValue(unsetMeta, 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	valueMeta, _, err := sel.Execute(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, tsquery.MetricKind(""), valueMeta.MetricKind, "both unset → output unset")
+}
+
+func TestReportSelectorFieldValue_KindMerge_DeltaVsCumulative_Error(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(reportValueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+	falseField := NewConstantFieldValue(reportValueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindCumulative), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	_, _, err := sel.Execute(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matching metric kinds")
+}
+
+func TestReportSelectorFieldValue_KindMerge_CumulativeVsRate_Error(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(reportValueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindCumulative), 5.0)
+	falseField := NewConstantFieldValue(reportValueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindRate), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	_, _, err := sel.Execute(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matching metric kinds")
+}
+
+func TestReportSelectorFieldValue_KindMerge_DeltaVsExplicitGauge_Error(t *testing.T) {
+	ctx := context.Background()
+	boolMeta := tsquery.ValueMeta{DataType: tsquery.DataTypeBoolean, Required: true}
+	cond := NewConstantFieldValue(boolMeta, true)
+	trueField := NewConstantFieldValue(reportValueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindDelta), 5.0)
+	falseField := NewConstantFieldValue(reportValueMetaWithKind(tsquery.DataTypeDecimal, tsquery.MetricKindGauge), 10.0)
+
+	sel := NewSelectorFieldValue(cond, trueField, falseField)
+	_, _, err := sel.Execute(ctx, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "matching metric kinds")
 }

--- a/utils/timeseries/tsquery/report/ref_report_field_value.go
+++ b/utils/timeseries/tsquery/report/ref_report_field_value.go
@@ -30,7 +30,7 @@ func (rf RefFieldValue) Execute(ctx context.Context, fieldsMeta []tsquery.FieldM
 
 	return tsquery.ValueMeta{
 		DataType:     fm.DataType(),
-		MetricKind:   fm.MetricKind(),
+		MetricKind:   fm.RawMetricKind(),
 		SamplePeriod: fm.SamplePeriod(),
 		Unit:         fm.Unit(),
 		Required:   fm.Required(),

--- a/utils/timeseries/tsquery/report/selector_report_field_value.go
+++ b/utils/timeseries/tsquery/report/selector_report_field_value.go
@@ -88,10 +88,26 @@ func (cf SelectorFieldValue) Execute(ctx context.Context, fieldsMeta []tsquery.F
 		)
 	}
 
+	// Validate metric kind: unset ("") is transparent, explicit kinds must match
+	trueKind := trueMeta.MetricKind
+	falseKind := falseMeta.MetricKind
+	if trueKind != falseKind {
+		if trueKind != "" && falseKind != "" {
+			return util.DefaultValue[tsquery.ValueMeta](), nil, fmt.Errorf(
+				"selector requires matching metric kinds: true=%s, false=%s",
+				trueKind, falseKind,
+			)
+		}
+	}
+	outputKind := trueKind
+	if trueKind == "" {
+		outputKind = falseKind
+	}
+
 	// Create field metadata
 	fvm := tsquery.ValueMeta{
 		DataType:     trueType,
-		MetricKind:   trueMeta.MetricKind,
+		MetricKind:   outputKind,
 		SamplePeriod: trueMeta.SamplePeriod,
 		Unit:         trueMeta.Unit,
 		Required:   trueMeta.Required,

--- a/utils/timeseries/tsquery/time_series_query.go
+++ b/utils/timeseries/tsquery/time_series_query.go
@@ -46,6 +46,14 @@ func (fm FieldMeta) MetricKind() MetricKind {
 	return fm.metricKind
 }
 
+// RawMetricKind returns the metric kind as declared, without normalization.
+// Returns "" if no kind was explicitly set. Use MetricKind() for resolved behavior;
+// use RawMetricKind() when preserving the unset-vs-explicit distinction matters
+// (e.g., selector validation, ValueMeta propagation).
+func (fm FieldMeta) RawMetricKind() MetricKind {
+	return fm.metricKind
+}
+
 func (fm FieldMeta) WithMetricKind(kind MetricKind) FieldMeta {
 	fm.metricKind = kind
 	return fm


### PR DESCRIPTION
…d smart defaults

Phase 1b — RawMetricKind() getter:
- Add RawMetricKind() to FieldMeta (returns raw value without "" → gauge normalization)
- Switch RefFieldValue (datasource + report) to propagate raw kind through ValueMeta
- Enables selector validation to distinguish unset from explicit gauge

Phase 2 — Kind-aware behavior:
- AlignerFilter smart defaults: auto-select Sum for delta, Last for cumulative when no explicit bucketReduction is set (gauge/rate unchanged)
- AlignerFilter output samplePeriod: derive from alignment period duration (fixed periods only, not calendar-based)
- DeltaFilter input validation: reject gauge, delta, and rate inputs (only cumulative accepted)
- DeltaFilter implicit gap threshold: use 2×samplePeriod when maxGapDuration is not explicitly set
- RateFilter input validation: reject rate-of-rate
- RateFilter implicit gap threshold: same 2×samplePeriod pattern
- Selector kind validation: gauge-transparent merge rule — unset ("") is transparent, explicit non-gauge kinds must match, error on mismatch

Tests: 40+ new/updated tests covering smart defaults with value assertions, gap boundary conditions (exactly 2x vs just-over-2x), implicit gap in both nonNegative and regular paths, selector merge matrix (both datasource and report sides), and golden integration tests (cumulative→delta→aligner pipeline, pipeline with gap, rate-of-rate rejection).

Existing e2e tests updated to tag datasources as cumulative where DeltaFilter is used, following the codegen pipeline (build.sh → generate.sh → generate-openapi.sh).