### PR TITLE
Fix aligner nil panic on optional fields during interpolation

### DIFF
--- a/utils/timeseries/tsquery/datasource/aligner_filter.go
+++ b/utils/timeseries/tsquery/datasource/aligner_filter.go
@@ -243,8 +243,16 @@ func alignmentPeriodClassifierFunc[T any](ap timeseries.AlignmentPeriod) func(a 
 	return func(a timeseries.TsRecord[T]) time.Time { return ap.GetStartTime(a.Timestamp) }
 }
 
-// timeWeightedAverageArr computes the time-weighted average of two values (v1Arr and v2Arr) erroring if the values are not numeric
+// timeWeightedAverage computes the time-weighted average of two values at their respective times.
+// Honors the optional-field nil contract: when either bracketing sample is nil, an optional field
+// (Required=false) produces nil; a required field surfaces a typed error naming the field URN.
 func timeWeightedAverage(fieldMeta tsquery.FieldMeta, targetTime, v1Time time.Time, v1 any, v2Time time.Time, v2 any) (any, error) {
+	if v1 == nil || v2 == nil {
+		if fieldMeta.Required() {
+			return nil, fmt.Errorf("aligner field %q is required but has nil bracketing sample", fieldMeta.Urn())
+		}
+		return nil, nil
+	}
 	if v1Time.Equal(v2Time) {
 		if v1Time == targetTime {
 			return v1, nil

--- a/utils/timeseries/tsquery/datasource/aligner_filter_test.go
+++ b/utils/timeseries/tsquery/datasource/aligner_filter_test.go
@@ -399,6 +399,73 @@ func TestAlignerFilter_BooleanDataType_UsesStepFunction(t *testing.T) {
 	require.Equal(t, false, alignedRecords[1].Value) // step function: use nearest value at 00:01:00
 }
 
+// --- Nil-handling for optional fields (Required=false) ---
+
+// TestAlignerFilter_OptionalFieldNil_PropagatesNil exercises the cross-cluster interpolation
+// path with an optional field carrying nil in one bracketing sample. Today this panics via the
+// raw float cast in DataType.ToFloat64; the fix propagates nil per the optional-field contract.
+func TestAlignerFilter_OptionalFieldNil_PropagatesNil(t *testing.T) {
+	ctx := context.Background()
+
+	fm, err := tsquery.NewFieldMetaFull("opt", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, false, "", nil)
+	require.NoError(t, err)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 10.0, Timestamp: time.Unix(30, 0)},
+		{Value: nil, Timestamp: time.Unix(90, 0)},
+	}
+
+	inputStream := stream.Just(records...)
+	staticDS, err := NewStaticDatasource(*fm, inputStream)
+	require.NoError(t, err)
+	result, err := staticDS.Execute(ctx, time.Unix(0, 0), time.Unix(120, 0))
+	require.NoError(t, err)
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(time.Minute, time.Local))
+	out, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+
+	got, err := out.Data().Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	// Cluster 0: smudge first item to bucket start.
+	require.Equal(t, time.Unix(0, 0), got[0].Timestamp)
+	require.InDelta(t, 10.0, got[0].Value.(float64), 1e-9)
+
+	// Cluster 1: bracket (10.0, nil) at t=60 → nil for optional field.
+	require.Equal(t, time.Unix(60, 0), got[1].Timestamp)
+	require.Nil(t, got[1].Value)
+}
+
+// TestAlignerFilter_RequiredFieldNil_ReturnsTypedError verifies that a required field with a nil
+// bracketing sample surfaces a typed error naming the field URN, rather than panicking.
+func TestAlignerFilter_RequiredFieldNil_ReturnsTypedError(t *testing.T) {
+	ctx := context.Background()
+
+	fm, err := tsquery.NewFieldMetaFull("must_be_set", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "", nil)
+	require.NoError(t, err)
+
+	records := []timeseries.TsRecord[any]{
+		{Value: 10.0, Timestamp: time.Unix(30, 0)},
+		{Value: nil, Timestamp: time.Unix(90, 0)},
+	}
+
+	inputStream := stream.Just(records...)
+	staticDS, err := NewStaticDatasource(*fm, inputStream)
+	require.NoError(t, err)
+	result, err := staticDS.Execute(ctx, time.Unix(0, 0), time.Unix(120, 0))
+	require.NoError(t, err)
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(time.Minute, time.Local))
+	out, err := af.Filter(ctx, result)
+	require.NoError(t, err)
+
+	_, err = out.Data().Collect(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `aligner field "must_be_set" is required but has nil bracketing sample`)
+}
+
 // --- Test Helper Functions ---
 
 // testAlignerFilterAsExpected runs the AlignerFilter.Filter method and asserts the output.

--- a/utils/timeseries/tsquery/report/aligner_report_filter.go
+++ b/utils/timeseries/tsquery/report/aligner_report_filter.go
@@ -255,23 +255,9 @@ func (af AlignerFilter) alignWithReductions(
 
 			// Interpolation fields replicate the no-reduction behavior: the first cluster (or an item
 			// already aligned to the slot) smudges the first value to the bucket start; otherwise the
-			// value is interpolated across the cluster boundary.
+			// value is interpolated across the cluster boundary. Accumulator indices skip interpolation
+			// entirely — their result comes from accs[i].Result() below.
 			needInterp := lastItemOnPreviousCluster != nil && firstItem.Timestamp != clusterTimestampClassifier
-			var interpArr []any
-			if needInterp {
-				interpArr, err = timeWeightedAverageArr(
-					fieldsMeta,
-					clusterTimestampClassifier,
-					lastItemOnPreviousCluster.Timestamp,
-					lastItemOnPreviousCluster.Value,
-					firstItem.Timestamp,
-					firstItem.Value,
-				)
-				if err != nil {
-					return util.DefaultValue[timeseries.TsRecord[[]any]](), fmt.Errorf(
-						"error calculating time weighted average while aligning streams: %w", err)
-				}
-			}
 
 			out := make([]any, len(fieldsMeta))
 			for i := range fieldsMeta {
@@ -279,7 +265,19 @@ func (af AlignerFilter) alignWithReductions(
 				case accs[i] != nil:
 					out[i] = accs[i].Result()
 				case needInterp:
-					out[i] = interpArr[i]
+					v, err := interpolateField(
+						fieldsMeta[i],
+						clusterTimestampClassifier,
+						lastItemOnPreviousCluster.Timestamp,
+						lastItemOnPreviousCluster.Value[i],
+						firstItem.Timestamp,
+						firstItem.Value[i],
+					)
+					if err != nil {
+						return util.DefaultValue[timeseries.TsRecord[[]any]](), fmt.Errorf(
+							"error calculating time weighted average while aligning streams: %w", err)
+					}
+					out[i] = v
 				default:
 					out[i] = firstItem.Value[i]
 				}
@@ -390,7 +388,7 @@ func (af AlignerFilter) fillGaps(
 				case timeseries.FillModeForwardFill:
 					out[i] = v1[i]
 				case timeseries.FillModeLinear:
-					val, err := timeWeightedAverageValue(outFieldsMeta[i].DataType(), targetTime, v1Time, v1[i], v2Time, v2[i])
+					val, err := interpolateField(outFieldsMeta[i], targetTime, v1Time, v1[i], v2Time, v2[i])
 					if err != nil {
 						return nil, err
 					}
@@ -418,18 +416,33 @@ func recordAlignmentPeriodClassifierFunc(ap timeseries.AlignmentPeriod) func(a t
 	return func(a timeseries.TsRecord[[]any]) time.Time { return ap.GetStartTime(a.Timestamp) }
 }
 
-// timeWeightedAverageArr computes the per-field time-weighted average of two value rows, erroring if
-// any value is not numeric.
+// timeWeightedAverageArr computes the per-field time-weighted average of two value rows. Nil
+// values propagate per field via interpolateField: optional fields produce nil; required fields
+// surface a typed error.
 func timeWeightedAverageArr(fieldsMeta []tsquery.FieldMeta, targetTime, v1Time time.Time, v1Arr []any, v2Time time.Time, v2Arr []any) ([]any, error) {
 	res := make([]any, len(v1Arr))
 	for i := range v1Arr {
-		v, err := timeWeightedAverageValue(fieldsMeta[i].DataType(), targetTime, v1Time, v1Arr[i], v2Time, v2Arr[i])
+		v, err := interpolateField(fieldsMeta[i], targetTime, v1Time, v1Arr[i], v2Time, v2Arr[i])
 		if err != nil {
 			return nil, err
 		}
 		res[i] = v
 	}
 	return res, nil
+}
+
+// interpolateField wraps timeWeightedAverageValue with the optional-field nil contract. When
+// either bracketing sample is nil, an optional field (Required=false) produces nil; a required
+// field surfaces a typed error naming the field URN. This mirrors how the rest of the library
+// (numeric expressions, accumulators) treats nil on optional fields.
+func interpolateField(fm tsquery.FieldMeta, targetTime, v1Time time.Time, v1 any, v2Time time.Time, v2 any) (any, error) {
+	if v1 == nil || v2 == nil {
+		if fm.Required() {
+			return nil, fmt.Errorf("aligner field %q is required but has nil bracketing sample", fm.Urn())
+		}
+		return nil, nil
+	}
+	return timeWeightedAverageValue(fm.DataType(), targetTime, v1Time, v1, v2Time, v2)
 }
 
 // timeWeightedAverageValue computes the time-weighted average of a single value between two

--- a/utils/timeseries/tsquery/report/aligner_report_filter_test.go
+++ b/utils/timeseries/tsquery/report/aligner_report_filter_test.go
@@ -370,6 +370,186 @@ func TestAlignerFilter_ErrorOnBooleanDataType(t *testing.T) {
 
 }
 
+// --- Nil-handling for optional fields (Required=false) ---
+
+// TestAlignerFilter_OptionalFieldNil_AlignWithReductions_GaugeBoundary exercises the reduction
+// path with a mixed-kind row: a Delta field (forces alignWithReductions) alongside an optional
+// Gauge field whose bracketing sample carries nil. The aligner must reduce the Delta to its
+// bucket sum and propagate nil for the Gauge instead of panicking on the raw float cast.
+func TestAlignerFilter_OptionalFieldNil_AlignWithReductions_GaugeBoundary(t *testing.T) {
+	ctx := context.Background()
+
+	deltaMeta, err := tsquery.NewFieldMetaFull("delta", tsquery.DataTypeDecimal, tsquery.MetricKindDelta, true, "", nil)
+	require.NoError(t, err)
+	gaugeMeta, err := tsquery.NewFieldMetaFull("gauge", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, false, "", nil)
+	require.NoError(t, err)
+	fieldsMeta := []tsquery.FieldMeta{*deltaMeta, *gaugeMeta}
+
+	records := []timeseries.TsRecord[[]any]{
+		{Value: []any{10.0, 5.0}, Timestamp: time.Unix(30, 0)}, // cluster 0 last
+		{Value: []any{10.0, nil}, Timestamp: time.Unix(90, 0)}, // cluster 1 first; gauge nil
+	}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(time.Minute, time.Local))
+	out, err := af.Filter(ctx, NewResult(fieldsMeta, stream.Just(records...)))
+	require.NoError(t, err)
+
+	got, err := out.Stream().Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	// Cluster 0: Delta sums to 10.0, Gauge falls through to firstItem (no needInterp).
+	require.Equal(t, time.Unix(0, 0), got[0].Timestamp)
+	require.InDelta(t, 10.0, got[0].Value[0].(float64), 1e-9)
+	require.InDelta(t, 5.0, got[0].Value[1].(float64), 1e-9)
+
+	// Cluster 1: Delta sums to 10.0, Gauge bracket is (5.0, nil) → nil for optional field.
+	require.Equal(t, time.Unix(60, 0), got[1].Timestamp)
+	require.InDelta(t, 10.0, got[1].Value[0].(float64), 1e-9)
+	require.Nil(t, got[1].Value[1])
+}
+
+// TestAlignerFilter_OptionalFieldNil_AlignByInterpolation exercises the pure interpolation
+// path (no Delta fields). An optional field with a nil bracket across the cluster boundary
+// must produce nil for that slot; the required field interpolates normally.
+func TestAlignerFilter_OptionalFieldNil_AlignByInterpolation(t *testing.T) {
+	ctx := context.Background()
+
+	requiredMeta, err := tsquery.NewFieldMetaFull("required", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "", nil)
+	require.NoError(t, err)
+	optionalMeta, err := tsquery.NewFieldMetaFull("optional", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, false, "", nil)
+	require.NoError(t, err)
+	fieldsMeta := []tsquery.FieldMeta{*requiredMeta, *optionalMeta}
+
+	records := []timeseries.TsRecord[[]any]{
+		{Value: []any{10.0, 5.0}, Timestamp: time.Unix(30, 0)},
+		{Value: []any{20.0, nil}, Timestamp: time.Unix(90, 0)},
+	}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(time.Minute, time.Local))
+	out, err := af.Filter(ctx, NewResult(fieldsMeta, stream.Just(records...)))
+	require.NoError(t, err)
+
+	got, err := out.Stream().Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	// Cluster 0: smudge firstItem to bucket start.
+	require.Equal(t, time.Unix(0, 0), got[0].Timestamp)
+	require.InDelta(t, 10.0, got[0].Value[0].(float64), 1e-9)
+	require.InDelta(t, 5.0, got[0].Value[1].(float64), 1e-9)
+
+	// Cluster 1: interpolate at t=60. Required: 10 + (20-10) * 0.5 = 15.0. Optional: nil.
+	require.Equal(t, time.Unix(60, 0), got[1].Timestamp)
+	require.InDelta(t, 15.0, got[1].Value[0].(float64), 1e-9)
+	require.Nil(t, got[1].Value[1])
+}
+
+// TestAlignerFilter_OptionalFieldNil_FillGaps_LinearPerField triggers the per-field dispatch
+// branch in fillGaps via a per-field FillMode override. An optional field whose interior
+// gap-fill neighbors include nil must produce nil for that slot, not panic.
+func TestAlignerFilter_OptionalFieldNil_FillGaps_LinearPerField(t *testing.T) {
+	ctx := context.Background()
+
+	ffMeta, err := tsquery.NewFieldMetaFull("ff", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "", nil)
+	require.NoError(t, err)
+	optMeta, err := tsquery.NewFieldMetaFull("opt", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, false, "", nil)
+	require.NoError(t, err)
+	fieldsMeta := []tsquery.FieldMeta{*ffMeta, *optMeta}
+
+	// Source rows at t=0 and t=120; cluster at t=60 is empty so the gap-filler runs there.
+	records := []timeseries.TsRecord[[]any]{
+		{Value: []any{10.0, 5.0}, Timestamp: time.Unix(0, 0)},
+		{Value: []any{20.0, nil}, Timestamp: time.Unix(120, 0)},
+	}
+
+	af := NewInterpolatingAlignerFilter(
+		timeseries.NewFixedAlignmentPeriod(time.Minute, time.Local),
+		timeseries.FillModeLinear,
+	).WithFieldFillMode("ff", timeseries.FillModeForwardFill)
+
+	out, err := af.Filter(ctx, NewResult(fieldsMeta, stream.Just(records...)))
+	require.NoError(t, err)
+
+	got, err := out.Stream().Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// t=0: source row aligned to bucket start.
+	require.Equal(t, time.Unix(0, 0), got[0].Timestamp)
+	require.InDelta(t, 10.0, got[0].Value[0].(float64), 1e-9)
+	require.InDelta(t, 5.0, got[0].Value[1].(float64), 1e-9)
+
+	// t=60: gap fill. ff is ForwardFill → 10.0. opt is Linear, brackets (5.0, nil) → nil.
+	require.Equal(t, time.Unix(60, 0), got[1].Timestamp)
+	require.InDelta(t, 10.0, got[1].Value[0].(float64), 1e-9)
+	require.Nil(t, got[1].Value[1])
+
+	// t=120: source row.
+	require.Equal(t, time.Unix(120, 0), got[2].Timestamp)
+	require.InDelta(t, 20.0, got[2].Value[0].(float64), 1e-9)
+	require.Nil(t, got[2].Value[1])
+}
+
+// TestAlignerFilter_OptionalFieldNil_FillGaps_SingleMode covers the no-overrides path in
+// fillGaps, which routes through timeWeightedAverageArr. Optional field with nil neighbor
+// must propagate nil for that slot.
+func TestAlignerFilter_OptionalFieldNil_FillGaps_SingleMode(t *testing.T) {
+	ctx := context.Background()
+
+	aMeta, err := tsquery.NewFieldMetaFull("a", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "", nil)
+	require.NoError(t, err)
+	optMeta, err := tsquery.NewFieldMetaFull("opt", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, false, "", nil)
+	require.NoError(t, err)
+	fieldsMeta := []tsquery.FieldMeta{*aMeta, *optMeta}
+
+	records := []timeseries.TsRecord[[]any]{
+		{Value: []any{10.0, 5.0}, Timestamp: time.Unix(0, 0)},
+		{Value: []any{20.0, nil}, Timestamp: time.Unix(120, 0)},
+	}
+
+	af := NewInterpolatingAlignerFilter(
+		timeseries.NewFixedAlignmentPeriod(time.Minute, time.Local),
+		timeseries.FillModeLinear,
+	)
+
+	out, err := af.Filter(ctx, NewResult(fieldsMeta, stream.Just(records...)))
+	require.NoError(t, err)
+
+	got, err := out.Stream().Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	// t=60: interior gap. a → linear interp 15.0. opt → nil.
+	require.Equal(t, time.Unix(60, 0), got[1].Timestamp)
+	require.InDelta(t, 15.0, got[1].Value[0].(float64), 1e-9)
+	require.Nil(t, got[1].Value[1])
+}
+
+// TestAlignerFilter_RequiredFieldNil_ReturnsTypedError verifies that a required field with a
+// nil bracketing sample surfaces a typed error naming the field URN, rather than panicking
+// via the raw float cast (which today gets caught by stream's recover with an opaque message).
+func TestAlignerFilter_RequiredFieldNil_ReturnsTypedError(t *testing.T) {
+	ctx := context.Background()
+
+	fm, err := tsquery.NewFieldMetaFull("must_be_set", tsquery.DataTypeDecimal, tsquery.MetricKindGauge, true, "", nil)
+	require.NoError(t, err)
+	fieldsMeta := []tsquery.FieldMeta{*fm}
+
+	records := []timeseries.TsRecord[[]any]{
+		{Value: []any{10.0}, Timestamp: time.Unix(30, 0)},
+		{Value: []any{nil}, Timestamp: time.Unix(90, 0)},
+	}
+
+	af := NewAlignerFilter(timeseries.NewFixedAlignmentPeriod(time.Minute, time.Local))
+	out, err := af.Filter(ctx, NewResult(fieldsMeta, stream.Just(records...)))
+	require.NoError(t, err)
+
+	_, err = out.Stream().Collect(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `aligner field "must_be_set" is required but has nil bracketing sample`)
+}
+
 // --- Test Helper Functions ---
 
 // testAlignerFilterAsExpected runs the AlignerFilter.Filter method and asserts the output.


### PR DESCRIPTION
report.AlignerFilter and datasource.AlignerFilter both interpolated through DataType.ToFloat64 unconditionally, and the DataTypeDecimal branch is a raw val.(float64) cast that panics on nil. Optional fields (Required=false), such as left-join right-side columns, would trigger this panic via the stream's recover with an opaque "interface conversion: interface {} is nil, not float64" error.

The rest of the library already treats Required=false as "value may be nil" (numeric expressions wrap their op with a nil-check; Sum/Avg accumulators skip nil). The aligner is now consistent: a nil bracketing sample on an optional field propagates nil; on a required field, a typed error names the field URN.

Changes:
- report.AlignerFilter: new interpolateField helper used by alignWithReductions (per-index dispatch — also drops the compute-then-discard interpArr smell), alignByInterpolation (via timeWeightedAverageArr), and fillGaps (both the single-mode and per-field-linear branches).
- datasource.AlignerFilter: same nil-check at the top of timeWeightedAverage.

Tests cover all four call paths plus the required-field-named-error case.

The untyped aligner (AlignStreamUntyped) is not affected — it uses util.AnyToFloat64 which errors cleanly on nil via its default branch.