### PR TITLE
Add DoFinally: local terminal-outcome observation hook

### DIFF
--- a/stream/do_finally.go
+++ b/stream/do_finally.go
@@ -1,0 +1,90 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"runtime/debug"
+	"slices"
+)
+
+// DoFinally registers f to run exactly once when this stream node terminates, on the consuming
+// goroutine, at Close (after the node stops producing). f runs after this node and its upstream have
+// been closed, so their resources are already torn down — f observes the terminal outcome, it does
+// not get a live view of upstream resources.
+//
+//	err == nil -> terminated without error (completed on io.EOF, or truncated early by e.g. Limit
+//	              or a downstream break).
+//	err != nil -> terminated with a pipeline error; external context cancellation surfaces as the
+//	              context error (use errors.Is(err, context.Canceled) / context.DeadlineExceeded to
+//	              detect it).
+//
+// DoFinally is local and compositional (like the Lifecycle Open/Close hooks): it observes this node
+// and everything upstream feeding it, wherever the node sits — including as a sub-stream inside a
+// combinator (Concat/Join/Merge/...). It does NOT observe errors produced by operators applied
+// *downstream* of it: such an error tears this node down cleanly, so f sees err == nil. To observe
+// the whole pipeline's terminal error, attach DoFinally as the outermost operator.
+//
+// The terminal error is matched against io.EOF by identity (io.EOF is normal completion, not an
+// error), consistent with the rest of the pipeline; an upstream that returns a %w-wrapped io.EOF
+// will therefore be reported here as a real error.
+//
+// f is purely observational: it must not mutate the stream or drive further emission. A
+// consumer-side failure (the consume callback erroring, or a consumer panic) is not the stream's
+// terminal outcome and is reported here as err == nil — that error remains the return value of
+// Consume/Collect/Reduce.
+func (s Stream[T]) DoFinally(f func(err error)) Stream[T] {
+	n := &finallyNode{f: f}
+	return newStream(
+		func(ctx context.Context) (T, error) {
+			v, err := s.provider(ctx)
+			// Record the terminal error the node's own subtree produced, so the Close hook can
+			// report it locally. io.EOF is normal completion, not an error.
+			if err != nil && err != io.EOF {
+				n.recordedErr = err
+			}
+			return v, err
+		},
+		append(slices.Clone(s.allLifecycleElement), n),
+	)
+}
+
+// finallyNode is the internal Lifecycle carrying a DoFinally callback. It captures its Open context
+// (so cancellation can be reported at Close) and the terminal error observed at the provider
+// boundary, then fires the callback exactly once per consumption when the node is closed.
+type finallyNode struct {
+	f           func(err error)
+	capturedCtx context.Context
+	recordedErr error
+	fired       bool
+}
+
+func (n *finallyNode) Open(ctx context.Context) error {
+	// Reset per-consumption state so re-consumption (double collection) fires again cleanly.
+	n.capturedCtx = ctx
+	n.recordedErr = nil
+	n.fired = false
+	return nil
+}
+
+func (n *finallyNode) Close() {
+	if n.fired {
+		return
+	}
+	n.fired = true
+
+	err := n.recordedErr
+	if err == nil && n.capturedCtx != nil {
+		// No provider error: if the (external) context was cancelled, that is the terminal outcome.
+		err = n.capturedCtx.Err()
+	}
+
+	// The hook is observational; a panic in it must not crash the consumer or leak through Close.
+	defer func() {
+		if rvr := recover(); rvr != nil {
+			slog.Error(fmt.Sprintf("DoFinally hook panicked: %v\n%s", rvr, debug.Stack()))
+		}
+	}()
+	n.f(err)
+}

--- a/stream/do_finally.go
+++ b/stream/do_finally.go
@@ -16,7 +16,10 @@ import (
 //
 //	err == nil -> terminated without error (completed on io.EOF, or truncated early by e.g. Limit
 //	              or a downstream break).
-//	err != nil -> terminated with a pipeline error; external context cancellation surfaces as the
+//	err != nil -> terminated with a pipeline error. This includes an open-stage failure (a lifecycle
+//	              Open returning an error, e.g. a source that cannot connect); in that case f runs
+//	              before the already-opened upstream siblings are torn down, since the open error
+//	              must win over the rollback close. External context cancellation surfaces as the
 //	              context error (use errors.Is(err, context.Canceled) / context.DeadlineExceeded to
 //	              detect it).
 //
@@ -79,12 +82,37 @@ func (n *finallyNode) Close() {
 		// No provider error: if the (external) context was cancelled, that is the terminal outcome.
 		err = n.capturedCtx.Err()
 	}
+	n.invoke(err)
+}
 
-	// The hook is observational; a panic in it must not crash the consumer or leak through Close.
+// fireOpenFailure fires the hook with an open-stage terminal error (a lifecycle Open returning an
+// error). Unlike Close it always fires when called — open failures can recur across re-consumptions
+// and the node's own Open may never have run — and it sets fired so the subsequent rollback Close
+// cannot fire again with nil.
+func (n *finallyNode) fireOpenFailure(err error) {
+	n.fired = true
+	n.invoke(err)
+}
+
+// invoke runs the observational callback under a panic guard so a buggy hook cannot crash the
+// consumer or leak through Open/Close.
+func (n *finallyNode) invoke(err error) {
 	defer func() {
 		if rvr := recover(); rvr != nil {
 			slog.Error(fmt.Sprintf("DoFinally hook panicked: %v\n%s", rvr, debug.Stack()))
 		}
 	}()
 	n.f(err)
+}
+
+// fireFinallyHooksOnOpenFailure notifies any DoFinally hooks among a stream's lifecycle elements
+// that the stream failed to open, so they observe the open-stage terminal error. It is called from
+// doOpenStream (the single open chokepoint for every consumer) before the rollback close, so this
+// error wins over Close's nil.
+func fireFinallyHooksOnOpenFailure(elements []Lifecycle, err error) {
+	for _, l := range elements {
+		if fn, ok := l.(*finallyNode); ok {
+			fn.fireOpenFailure(err)
+		}
+	}
 }

--- a/stream/do_finally_test.go
+++ b/stream/do_finally_test.go
@@ -1,0 +1,264 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errAt returns a Map that yields values unchanged but errors when it reaches `bad`, simulating a
+// provider/emit-stage error (as opposed to Error(), which fails at Open).
+func errAt(s Stream[int], bad int, err error) Stream[int] {
+	return MapWithErr(s, func(i int) (int, error) {
+		if i == bad {
+			return 0, err
+		}
+		return i, nil
+	})
+}
+
+func TestDoFinally_SuccessFiresNilOnce(t *testing.T) {
+	var calls int
+	var got error
+	got = errors.New("sentinel-not-called")
+
+	out, err := Just(1, 2, 3).
+		DoFinally(func(e error) { calls++; got = e }).
+		Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, out)
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
+}
+
+func TestDoFinally_ProviderErrorFiresThatError(t *testing.T) {
+	boom := errors.New("boom")
+	var calls int
+	var got error
+
+	_, err := errAt(Just(1, 2, 3, 4), 3, boom).
+		DoFinally(func(e error) { calls++; got = e }).
+		Collect(context.Background())
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, got, boom)
+}
+
+func TestDoFinally_ContextCancelMidDrainFiresContextErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int
+	var got error
+
+	err := Just(1, 2, 3, 4, 5).
+		DoFinally(func(e error) { calls++; got = e }).
+		Consume(ctx, func(v int) {
+			if v == 2 {
+				cancel()
+			}
+		})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, got, context.Canceled)
+}
+
+func TestDoFinally_LimitTruncationFiresNil(t *testing.T) {
+	// DoFinally is *inside* the Limit: the wrapped node is truncated before its own EOF, which is a
+	// clean stop, not an error.
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	out, err := Just(1, 2, 3, 4, 5).
+		DoFinally(func(e error) { calls++; got = e }).
+		Limit(2).
+		Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, out)
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
+}
+
+func TestDoFinally_BuriedInConcatFiresLocally(t *testing.T) {
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	s1 := Just(1, 2).DoFinally(func(e error) { calls++; got = e })
+	s2 := Just(3, 4)
+
+	out, err := ConcatStreams(s1, s2).Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4}, out)
+	// s1 completes locally (EOF) as concat advances to s2.
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
+}
+
+// The decisive per-node case: in a merge of s1,s2 (both open), when s1 errors midway s1's DoFinally
+// must fire that error while s2's — healthy, merely torn down — fires nil.
+func TestDoFinally_MergeErrorIsPerNode(t *testing.T) {
+	boom := errors.New("boom")
+
+	var s1Calls, s2Calls int
+	var s1Err, s2Err error
+	s2Err = errors.New("sentinel-not-called")
+
+	s1 := errAt(Just(10, 20), 20, boom).
+		DoFinally(func(e error) { s1Calls++; s1Err = e })
+	s2 := Just(15, 25).
+		DoFinally(func(e error) { s2Calls++; s2Err = e })
+
+	_, err := MergeSortedStreams(func(a, b int) int { return a - b }, s1, s2).
+		Collect(context.Background())
+
+	require.Error(t, err)
+
+	require.Equal(t, 1, s1Calls)
+	require.ErrorIs(t, s1Err, boom)
+
+	require.Equal(t, 1, s2Calls)
+	require.NoError(t, s2Err) // s2 was cancelled, not errored
+}
+
+func TestDoFinally_SurvivesDownstreamOperators(t *testing.T) {
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	s := Just(1, 2, 3, 4, 5, 6).DoFinally(func(e error) { calls++; got = e })
+	out, err := Map(s, func(i int) int { return i * 10 }).
+		Filter(func(i int) bool { return i > 20 }).
+		Limit(2).
+		Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []int{30, 40}, out)
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
+}
+
+func TestDoFinally_FiresOncePerConsumption(t *testing.T) {
+	var calls int
+	s := Just(1, 2, 3).DoFinally(func(e error) { calls++ })
+
+	_, err := s.Collect(context.Background())
+	require.NoError(t, err)
+	_, err = s.Collect(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, 2, calls)
+}
+
+func TestDoFinally_PanickingHookDoesNotCrashConsumer(t *testing.T) {
+	out, err := Just(1, 2, 3).
+		DoFinally(func(e error) { panic("hook boom") }).
+		Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, out)
+}
+
+func TestDoFinally_ConsumerCallbackErrorFiresNil(t *testing.T) {
+	callbackErr := errors.New("callback failed")
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	err := Just(1, 2, 3).
+		DoFinally(func(e error) { calls++; got = e }).
+		ConsumeWithErr(context.Background(), func(v int) error {
+			if v == 2 {
+				return callbackErr
+			}
+			return nil
+		})
+
+	require.ErrorIs(t, err, callbackErr)
+	require.Equal(t, 1, calls)
+	// Consumer-side failure is not the stream's terminal outcome (documented limitation).
+	require.NoError(t, got)
+}
+
+func TestDoFinally_ConcurrentConsumeFiresOnce(t *testing.T) {
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	err := Just(1, 2, 3, 4, 5).
+		DoFinally(func(e error) { calls++; got = e }).
+		Consume(context.Background(), func(v int) {}, WithConcurrentConsumeOption(2))
+
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
+}
+
+func TestDoFinally_ConcurrentConsumeErrorFiresError(t *testing.T) {
+	boom := errors.New("boom")
+	var calls int
+	var got error
+
+	err := errAt(Just(1, 2, 3, 4, 5, 6), 4, boom).
+		DoFinally(func(e error) { calls++; got = e }).
+		Consume(context.Background(), func(v int) {}, WithConcurrentConsumeOption(3))
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, got, boom)
+}
+
+func TestDoFinally_EmptyStreamFiresNil(t *testing.T) {
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	out, err := Empty[int]().
+		DoFinally(func(e error) { calls++; got = e }).
+		Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Empty(t, out)
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
+}
+
+func TestDoFinally_MultipleHooksAllFire(t *testing.T) {
+	boom := errors.New("boom")
+	var a, b error
+	var aCalls, bCalls int
+
+	_, err := errAt(Just(1, 2, 3), 2, boom).
+		DoFinally(func(e error) { aCalls++; a = e }).
+		DoFinally(func(e error) { bCalls++; b = e }).
+		Collect(context.Background())
+
+	require.Error(t, err)
+	require.Equal(t, 1, aCalls)
+	require.Equal(t, 1, bCalls)
+	require.ErrorIs(t, a, boom)
+	require.ErrorIs(t, b, boom)
+}
+
+// A panic inside the pipeline is recovered by the consumer and surfaces as its returned error;
+// it does not travel back through the provider as a value, so DoFinally reports nil (documented
+// limitation, same bucket as consumer-side failures). This test pins that behavior.
+func TestDoFinally_PipelinePanicFiresNil(t *testing.T) {
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	_, err := Map(Just(1, 2, 3), func(i int) int {
+		if i == 2 {
+			panic("pipeline boom")
+		}
+		return i
+	}).
+		DoFinally(func(e error) { calls++; got = e }).
+		Collect(context.Background())
+
+	require.Error(t, err) // consumer still surfaces the panic as an error
+	require.Equal(t, 1, calls)
+	require.NoError(t, got) // ... but DoFinally does not observe it
+}

--- a/stream/do_finally_test.go
+++ b/stream/do_finally_test.go
@@ -19,6 +19,63 @@ func errAt(s Stream[int], bad int, err error) Stream[int] {
 	})
 }
 
+func TestDoFinally_OpenFailureFiresError(t *testing.T) {
+	boom := errors.New("boom")
+	var calls int
+	var got error
+
+	_, err := Error[int](boom).
+		DoFinally(func(e error) { calls++; got = e }).
+		Collect(context.Background())
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, boom)
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, got, boom)
+}
+
+func TestDoFinally_OpenFailureBuriedUnderOperatorFiresError(t *testing.T) {
+	boom := errors.New("boom")
+	var calls int
+	var got error
+
+	s := Error[int](boom).DoFinally(func(e error) { calls++; got = e })
+	_, err := Map(s, func(i int) int { return i }).
+		Filter(func(i int) bool { return true }).
+		Collect(context.Background())
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, got, boom)
+}
+
+func TestDoFinally_OpenFailureConcurrentConsumeFiresError(t *testing.T) {
+	boom := errors.New("boom")
+	var calls int
+	var got error
+
+	err := Error[int](boom).
+		DoFinally(func(e error) { calls++; got = e }).
+		Consume(context.Background(), func(v int) {}, WithConcurrentConsumeOption(2))
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+	require.ErrorIs(t, got, boom)
+}
+
+func TestDoFinally_OpenFailureFiresOncePerConsumption(t *testing.T) {
+	boom := errors.New("boom")
+	var calls int
+	s := Error[int](boom).DoFinally(func(e error) { calls++ })
+
+	_, err := s.Collect(context.Background())
+	require.Error(t, err)
+	_, err = s.Collect(context.Background())
+	require.Error(t, err)
+
+	require.Equal(t, 2, calls)
+}
+
 func TestDoFinally_SuccessFiresNilOnce(t *testing.T) {
 	var calls int
 	var got error

--- a/stream/shpan_stream.go
+++ b/stream/shpan_stream.go
@@ -305,6 +305,12 @@ func doOpenStream[T any](ctx context.Context, s Stream[T]) (context.CancelFunc, 
 			// If we fail to open a lifecycle element, we need to close all previously opened elements
 			// and return the error
 
+			openErr := fmt.Errorf("failed to open stream lifecycle element %d: %w", lcIdx, err)
+
+			// Notify DoFinally hooks of the open-stage terminal error before the rollback close,
+			// so this error wins over any already-opened hook's Close (which would fire nil).
+			fireFinallyHooksOnOpenFailure(s.allLifecycleElement, openErr)
+
 			// Close only the successfully opened lifecycle elements
 			for i := 0; i < lcIdx; i++ {
 				s.allLifecycleElement[i].Close()
@@ -312,7 +318,7 @@ func doOpenStream[T any](ctx context.Context, s Stream[T]) (context.CancelFunc, 
 			// Cancel the context to stop any ongoing operations
 			cancelFunc()
 
-			return nil, fmt.Errorf("failed to open stream lifecycle element %d: %w", lcIdx, err)
+			return nil, openErr
 		}
 	}
 	return cancelFunc, nil


### PR DESCRIPTION
DoFinally(f func(err error)) fires exactly once when a stream node terminates, completing the Lifecycle Open/Close triad with the outcome: nil on clean completion or early truncation, the provider error on failure, and the context error on cancellation (errors.Is-detectable).

Semantics are local and compositional, matching Open/Close and the standard primitive in Reactor/RxJava/Pekko: the hook observes the node it is attached to (and everything upstream feeding it), wherever it sits -- including buried inside a combinator (Concat/Join/Merge). Implemented via node self-tracking -- a Peek-style provider-wrapper records the terminal signal and the node's own Close hook resolves (recordedErr -> ctx.Err() -> nil) and fires it -- so it needs no combinator cooperation, adds no Stream field, changes no existing behavior, and is non-breaking. The hook is panic-guarded and re-consumption safe.

Covered by stream/do_finally_test.go: success, provider error, ctx cancel, limit truncation, buried-in-concat, per-node merge error, downstream operators, re-consumption, panicking hook, consumer-callback error, concurrent consume (+error), empty stream, multiple hooks, and pipeline-panic behavior.