### PR TITLE
Join Buffered's goroutine at teardown; release concurrent map's eofCtx

### DIFF
--- a/stream/buffered_stream.go
+++ b/stream/buffered_stream.go
@@ -21,6 +21,12 @@ func Buffered[T any](s Stream[T], size int) Stream[T] {
 	// Result will either be T or an upstream error
 	bufferChan := make(chan shpanstream.Result[T], size-1)
 
+	// internalCtx bounds the buffering goroutine so close can cancel and join it. The join must be
+	// driven by our own cancel: the consumer's teardown runs lifecycle Close funcs BEFORE cancelling
+	// the consume ctx, so waiting on the outer ctx here would deadlock.
+	var internalCancel context.CancelFunc
+	bufferingDone := make(chan struct{})
+
 	return MapWithErr(
 		// Create a new stream with the buffer channel as the source
 		FromChannel(bufferChan),
@@ -31,17 +37,23 @@ func Buffered[T any](s Stream[T], size int) Stream[T] {
 		// Attach handler to the Open func of the stream lifecycle to trigger the buffering goroutine
 		WithAdditionalLifecycle(NewLifecycle(
 			func(ctx context.Context) error {
+				internalCtx, cancel := context.WithCancel(ctx)
+				internalCancel = cancel
 
 				// Start Reading from the source stream and populate the buffer channel
 				go func() {
+					// bufferingDone is closed last (LIFO), after the source's Consume has fully torn
+					// down, so a close() blocked on <-bufferingDone is released only once the source
+					// is closed.
+					defer close(bufferingDone)
 					// Make sure to close the buffer channel when either the source stream is done, or the context is cancelled
 					defer close(bufferChan)
 
-					err := s.Consume(ctx, func(v T) {
+					err := s.Consume(internalCtx, func(v T) {
 						// Write to the buffer channel
 						select {
 						case bufferChan <- shpanstream.Result[T]{Value: v}:
-						case <-ctx.Done():
+						case <-internalCtx.Done():
 						}
 					})
 
@@ -49,20 +61,27 @@ func Buffered[T any](s Stream[T], size int) Stream[T] {
 					if err != nil {
 						select {
 						case bufferChan <- shpanstream.Result[T]{Err: err}:
-						case <-ctx.Done():
+						case <-internalCtx.Done():
 						}
 					} else {
 						// If we are here, it means processing the source stream finished successfully,
 						// "celebrating" it by putting an EOF in the buffer channel
 						select {
 						case bufferChan <- shpanstream.Result[T]{Err: io.EOF}:
-						case <-ctx.Done():
+						case <-internalCtx.Done():
 						}
 					}
 				}()
 				return nil
 			},
 			func() {
+				// Cancel the buffering goroutine and join it, so the source is fully closed (its
+				// Consume returned) by the time the stream reports closed. Without the join the
+				// goroutine outlives Consume and the source teardown races with the caller.
+				if internalCancel != nil {
+					internalCancel()
+					<-bufferingDone
+				}
 			},
 		))
 }

--- a/stream/buffered_stream_test.go
+++ b/stream/buffered_stream_test.go
@@ -38,6 +38,49 @@ func TestBuffered_EmptyStream(t *testing.T) {
 	require.Empty(t, out)
 }
 
+// Regression: Buffered's teardown must cancel and join the buffering goroutine, so the source is
+// fully closed by the time Consume returns. Without the join, the goroutine (and the source's
+// Close) outlives the stream, racing with callers that release resources right after Consume.
+func TestBuffered_SourceClosedBeforeConsumeReturns(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		var sourceClosed atomic.Bool
+		src := Just(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).
+			WithAdditionalLifecycle(NewLifecycle(
+				func(ctx context.Context) error { return nil },
+				func() { sourceClosed.Store(true) },
+			))
+
+		// Stop early so the buffering goroutine is still in flight (blocked on a full buffer)
+		// when teardown runs.
+		out, err := Buffered(src, 3).Limit(2).Collect(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []int{1, 2}, out)
+		require.True(t, sourceClosed.Load(), "source must be closed by the time Consume returns")
+	}
+}
+
+// Same invariant when the source is blocked inside its provider and the consumer's ctx expires.
+// The source's Close is deliberately slow: only a teardown that joins the buffering goroutine
+// (which owns the source lifecycle) observes the flag as set.
+func TestBuffered_TeardownReleasesBlockedSource(t *testing.T) {
+	var sourceClosed atomic.Bool
+	neverWritten := make(chan int)
+	src := FromChannel(neverWritten).
+		WithAdditionalLifecycle(NewLifecycle(
+			func(ctx context.Context) error { return nil },
+			func() {
+				time.Sleep(20 * time.Millisecond)
+				sourceClosed.Store(true)
+			},
+		))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, err := Buffered(src, 3).Collect(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.True(t, sourceClosed.Load(), "source must be closed by the time Consume returns")
+}
+
 func TestStream_Buffered(t *testing.T) {
 	iterationCounter := atomic.Int32{}
 	actuallyReadCounter := atomic.Int32{}

--- a/stream/concurrent_stream.go
+++ b/stream/concurrent_stream.go
@@ -18,6 +18,7 @@ type concurrentStreamMapperProvider[SRC any, TGT any] struct {
 	srcChan        chan shpanstream.Result[SRC]
 	tgtChan        chan shpanstream.Result[TGT]
 	eofCtx         context.Context
+	eofCancel      context.CancelFunc
 	internalCancel context.CancelFunc
 	srcCancel      context.CancelFunc
 	producerDone   chan struct{}
@@ -69,6 +70,7 @@ func (c *concurrentStreamMapperProvider[SRC, TGT]) open(ctx context.Context) err
 	// eofCtx lets emit distinguish "closed because the source reached EOF" from "closed on cancel".
 	eofCtx, eofCancelFunc := context.WithCancel(context.Background())
 	c.eofCtx = eofCtx
+	c.eofCancel = eofCancelFunc
 
 	// Closed only after the reader and every worker have fully exited, so close can join on it.
 	c.producerDone = make(chan struct{})
@@ -196,5 +198,10 @@ func (c *concurrentStreamMapperProvider[SRC, TGT]) close() {
 	doCloseSubStream[SRC](c.src)
 	if c.srcCancel != nil {
 		c.srcCancel()
+	}
+	// On early termination the reader never reaches EOF and eofCancelFunc was never called;
+	// release the eofCtx here (calling it twice is safe).
+	if c.eofCancel != nil {
+		c.eofCancel()
 	}
 }

--- a/stream/concurrent_stream_test.go
+++ b/stream/concurrent_stream_test.go
@@ -71,6 +71,26 @@ func TestConcurrentMap_ReConsumable(t *testing.T) {
 	}
 }
 
+// On early termination the reader never reaches EOF, so eofCancelFunc was never called and the
+// eofCtx leaked un-cancelled. close must cancel it.
+func TestConcurrentMap_EofCtxCancelledOnEarlyStop(t *testing.T) {
+	src := make([]int, 100)
+	for i := range src {
+		src[i] = i
+	}
+	c := &concurrentStreamMapperProvider[int, int]{
+		concurrency: 2,
+		mapper:      func(_ context.Context, v int) (int, error) { return v, nil },
+		src:         Just(src...),
+	}
+	s := NewSimpleStream(c.emit, WithOpenFuncOption(c.open), WithCloseFuncOption(c.close))
+
+	out, err := s.Limit(1).Collect(context.Background())
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Error(t, c.eofCtx.Err(), "close must cancel eofCtx so its resources are released")
+}
+
 // A mapper error is surfaced.
 func TestConcurrentMap_MapperErrorSurfaced(t *testing.T) {
 	boom := errors.New("boom")


### PR DESCRIPTION
Buffered's buffering goroutine owned the source lifecycle but its close func was empty, so on early termination (Limit, ctx cancellation) the goroutine -- and the source's Close -- outlived Consume. A caller releasing a resource (DB handle, file) right after Consume returned could race with the source's in-flight teardown.

Apply the same join-before-close pattern as the concurrent map fix: bound the goroutine with an internal context and have the lifecycle close func cancel it and join on a done channel. The internal cancel is required because the consumer's teardown runs lifecycle Close funcs before cancelling the consume ctx -- waiting on the outer ctx would deadlock.

Also release the concurrent map's eofCtx in close(): on early termination the reader never reaches EOF, so eofCancelFunc was never called and the context leaked un-cancelled.

Tests: source-closed-before-Consume-returns via Limit and via ctx timeout with a blocked provider (both fail without the join, the latter made deterministic by a slow source Close), and eofCtx cancelled on early stop. All verified failing before the fix, and pass under -race.