### PR TITLE
Make Buffered re-consumable; drop the io.EOF sentinel

### DIFF
--- a/stream/buffered_stream.go
+++ b/stream/buffered_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/shpandrak/shpanstream"
+	"github.com/shpandrak/shpanstream/internal/util"
 	"io"
 )
 
@@ -15,73 +16,80 @@ func Buffered[T any](s Stream[T], size int) Stream[T] {
 	if size == 1 {
 		return s
 	}
+	b := &bufferedStreamProvider[T]{src: s, size: size}
+	return NewSimpleStream(b.emit, WithOpenFuncOption(b.open), WithCloseFuncOption(b.close))
+}
 
-	// Create a buffered channel of type Result size-1
-	// (-1 since one item will block while trying to write to the channel)
-	// Result will either be T or an upstream error
-	bufferChan := make(chan shpanstream.Result[T], size-1)
+// bufferedStreamProvider drains the source on a background goroutine into a buffered channel. All
+// channel state is created per Open (not once), so the stream is re-consumable (double collection).
+type bufferedStreamProvider[T any] struct {
+	src  Stream[T]
+	size int
+
+	// Per-consumption state, (re)initialised in open and torn down in close.
+	bufferChan     chan shpanstream.Result[T]
+	internalCancel context.CancelFunc
+	bufferingDone  chan struct{}
+}
+
+func (b *bufferedStreamProvider[T]) open(ctx context.Context) error {
+	// Buffer holds size-1 items (one more item blocks in the send while the buffer is full).
+	bufferChan := make(chan shpanstream.Result[T], b.size-1)
 
 	// internalCtx bounds the buffering goroutine so close can cancel and join it. The join must be
 	// driven by our own cancel: the consumer's teardown runs lifecycle Close funcs BEFORE cancelling
 	// the consume ctx, so waiting on the outer ctx here would deadlock.
-	var internalCancel context.CancelFunc
+	internalCtx, cancel := context.WithCancel(ctx)
 	bufferingDone := make(chan struct{})
 
-	return MapWithErr(
-		// Create a new stream with the buffer channel as the source
-		FromChannel(bufferChan),
+	b.bufferChan = bufferChan
+	b.internalCancel = cancel
+	b.bufferingDone = bufferingDone
 
-		// Unpack the result from the buffer channel to the original type or error
-		shpanstream.UnpackResult[T],
-	).
-		// Attach handler to the Open func of the stream lifecycle to trigger the buffering goroutine
-		WithAdditionalLifecycle(NewLifecycle(
-			func(ctx context.Context) error {
-				internalCtx, cancel := context.WithCancel(ctx)
-				internalCancel = cancel
+	go func() {
+		// bufferingDone is closed last (LIFO), after the source's Consume has fully torn down, so a
+		// close() blocked on <-bufferingDone is released only once the source is closed.
+		defer close(bufferingDone)
+		// Closing bufferChan signals normal completion (io.EOF) to the consumer side.
+		defer close(bufferChan)
 
-				// Start Reading from the source stream and populate the buffer channel
-				go func() {
-					// bufferingDone is closed last (LIFO), after the source's Consume has fully torn
-					// down, so a close() blocked on <-bufferingDone is released only once the source
-					// is closed.
-					defer close(bufferingDone)
-					// Make sure to close the buffer channel when either the source stream is done, or the context is cancelled
-					defer close(bufferChan)
+		err := b.src.Consume(internalCtx, func(v T) {
+			select {
+			case bufferChan <- shpanstream.Result[T]{Value: v}:
+			case <-internalCtx.Done():
+			}
+		})
+		// A real upstream error is forwarded through the buffer; normal completion (nil) is signalled
+		// by the deferred close of bufferChan.
+		if err != nil {
+			select {
+			case bufferChan <- shpanstream.Result[T]{Err: err}:
+			case <-internalCtx.Done():
+			}
+		}
+	}()
+	return nil
+}
 
-					err := s.Consume(internalCtx, func(v T) {
-						// Write to the buffer channel
-						select {
-						case bufferChan <- shpanstream.Result[T]{Value: v}:
-						case <-internalCtx.Done():
-						}
-					})
+func (b *bufferedStreamProvider[T]) emit(ctx context.Context) (T, error) {
+	select {
+	case <-ctx.Done():
+		return util.DefaultValue[T](), ctx.Err()
+	case r, stillGood := <-b.bufferChan:
+		if !stillGood {
+			// The buffering goroutine closed the channel: the source completed normally.
+			return util.DefaultValue[T](), io.EOF
+		}
+		return r.Unpack()
+	}
+}
 
-					// If an upstream error occurs, we need to send it to the buffer channel
-					if err != nil {
-						select {
-						case bufferChan <- shpanstream.Result[T]{Err: err}:
-						case <-internalCtx.Done():
-						}
-					} else {
-						// If we are here, it means processing the source stream finished successfully,
-						// "celebrating" it by putting an EOF in the buffer channel
-						select {
-						case bufferChan <- shpanstream.Result[T]{Err: io.EOF}:
-						case <-internalCtx.Done():
-						}
-					}
-				}()
-				return nil
-			},
-			func() {
-				// Cancel the buffering goroutine and join it, so the source is fully closed (its
-				// Consume returned) by the time the stream reports closed. Without the join the
-				// goroutine outlives Consume and the source teardown races with the caller.
-				if internalCancel != nil {
-					internalCancel()
-					<-bufferingDone
-				}
-			},
-		))
+func (b *bufferedStreamProvider[T]) close() {
+	// Cancel the buffering goroutine and join it, so the source is fully closed (its Consume
+	// returned) by the time the stream reports closed. Without the join the goroutine outlives
+	// Consume and the source teardown races with the caller.
+	if b.internalCancel != nil {
+		b.internalCancel()
+		<-b.bufferingDone
+	}
 }

--- a/stream/buffered_stream.go
+++ b/stream/buffered_stream.go
@@ -9,6 +9,8 @@ import (
 )
 
 // Buffered creates a buffered stream from the source stream with a given buffer size.
+// The resulting stream is re-consumable sequentially, but (like all streams) must not be consumed
+// concurrently.
 func Buffered[T any](s Stream[T], size int) Stream[T] {
 	if size <= 0 {
 		return Error[T](fmt.Errorf("buffer size must be greater than 0"))
@@ -30,6 +32,8 @@ type bufferedStreamProvider[T any] struct {
 	bufferChan     chan shpanstream.Result[T]
 	internalCancel context.CancelFunc
 	bufferingDone  chan struct{}
+	eofCtx         context.Context
+	eofCancel      context.CancelFunc
 }
 
 func (b *bufferedStreamProvider[T]) open(ctx context.Context) error {
@@ -42,9 +46,15 @@ func (b *bufferedStreamProvider[T]) open(ctx context.Context) error {
 	internalCtx, cancel := context.WithCancel(ctx)
 	bufferingDone := make(chan struct{})
 
+	// eofCtx lets emit distinguish "channel closed because the source reached EOF" from "closed on
+	// cancel" (mirrors the concurrent map provider).
+	eofCtx, eofCancel := context.WithCancel(context.Background())
+
 	b.bufferChan = bufferChan
 	b.internalCancel = cancel
 	b.bufferingDone = bufferingDone
+	b.eofCtx = eofCtx
+	b.eofCancel = eofCancel
 
 	go func() {
 		// bufferingDone is closed last (LIFO), after the source's Consume has fully torn down, so a
@@ -60,12 +70,14 @@ func (b *bufferedStreamProvider[T]) open(ctx context.Context) error {
 			}
 		})
 		// A real upstream error is forwarded through the buffer; normal completion (nil) is signalled
-		// by the deferred close of bufferChan.
+		// by cancelling eofCtx before the deferred close of bufferChan.
 		if err != nil {
 			select {
 			case bufferChan <- shpanstream.Result[T]{Err: err}:
 			case <-internalCtx.Done():
 			}
+		} else {
+			eofCancel()
 		}
 	}()
 	return nil
@@ -77,8 +89,16 @@ func (b *bufferedStreamProvider[T]) emit(ctx context.Context) (T, error) {
 		return util.DefaultValue[T](), ctx.Err()
 	case r, stillGood := <-b.bufferChan:
 		if !stillGood {
-			// The buffering goroutine closed the channel: the source completed normally.
-			return util.DefaultValue[T](), io.EOF
+			// The buffering goroutine closed the channel; eofCtx tells apart normal completion from
+			// a close driven by cancellation (where the pending error may have been dropped).
+			if b.eofCtx.Err() != nil {
+				return util.DefaultValue[T](), io.EOF
+			}
+			if ctx.Err() != nil {
+				return util.DefaultValue[T](), ctx.Err()
+			}
+			// Should never happen
+			return util.DefaultValue[T](), fmt.Errorf("buffered stream channel closed prematurely")
 		}
 		return r.Unpack()
 	}
@@ -91,5 +111,10 @@ func (b *bufferedStreamProvider[T]) close() {
 	if b.internalCancel != nil {
 		b.internalCancel()
 		<-b.bufferingDone
+	}
+	// On early termination the goroutine never signals EOF and eofCancel was never called; release
+	// the eofCtx here (calling it twice is safe).
+	if b.eofCancel != nil {
+		b.eofCancel()
 	}
 }

--- a/stream/buffered_stream_test.go
+++ b/stream/buffered_stream_test.go
@@ -38,6 +38,30 @@ func TestBuffered_EmptyStream(t *testing.T) {
 	require.Empty(t, out)
 }
 
+// Buffered must be re-consumable (double collection): channel state is created per Open, so a
+// second consumption drains the source again rather than returning an empty result.
+func TestBuffered_ReConsumable(t *testing.T) {
+	s := Buffered(Just(1, 2, 3, 4, 5), 3)
+	for i := 0; i < 3; i++ {
+		out, err := s.Collect(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []int{1, 2, 3, 4, 5}, out)
+	}
+}
+
+// Re-consumption must also hold after an early-terminated consumption (teardown joins the goroutine
+// and resets state cleanly).
+func TestBuffered_ReConsumableAfterEarlyStop(t *testing.T) {
+	s := Buffered(Just(1, 2, 3, 4, 5), 2)
+	partial, err := s.Limit(2).Collect(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, partial)
+
+	full, err := s.Collect(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4, 5}, full)
+}
+
 // Regression: Buffered's teardown must cancel and join the buffering goroutine, so the source is
 // fully closed by the time Consume returns. Without the join, the goroutine (and the source's
 // Close) outlives the stream, racing with callers that release resources right after Consume.

--- a/stream/buffered_stream_test.go
+++ b/stream/buffered_stream_test.go
@@ -62,6 +62,22 @@ func TestBuffered_ReConsumableAfterEarlyStop(t *testing.T) {
 	require.Equal(t, []int{1, 2, 3, 4, 5}, full)
 }
 
+// On early termination the buffering goroutine never signals EOF, so close must release the
+// eofCtx (mirrors TestConcurrentMap_EofCtxCancelledOnEarlyStop).
+func TestBuffered_EofCtxCancelledOnEarlyStop(t *testing.T) {
+	src := make([]int, 100)
+	for i := range src {
+		src[i] = i
+	}
+	b := &bufferedStreamProvider[int]{src: Just(src...), size: 3}
+	s := NewSimpleStream(b.emit, WithOpenFuncOption(b.open), WithCloseFuncOption(b.close))
+
+	out, err := s.Limit(1).Collect(context.Background())
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Error(t, b.eofCtx.Err(), "close must cancel eofCtx so its resources are released")
+}
+
 // Regression: Buffered's teardown must cancel and join the buffering goroutine, so the source is
 // fully closed by the time Consume returns. Without the join, the goroutine (and the source's
 // Close) outlives the stream, racing with callers that release resources right after Consume.

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,28 @@
+package shpanstream
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResultUnpack(t *testing.T) {
+	v, err := Result[int]{Value: 42}.Unpack()
+	require.NoError(t, err)
+	require.Equal(t, 42, v)
+
+	boom := errors.New("boom")
+	_, err = Result[int]{Err: boom}.Unpack()
+	require.ErrorIs(t, err, boom)
+}
+
+func TestUnpackResult(t *testing.T) {
+	v, err := UnpackResult(Result[string]{Value: "hello"})
+	require.NoError(t, err)
+	require.Equal(t, "hello", v)
+
+	boom := errors.New("boom")
+	_, err = UnpackResult(Result[string]{Err: boom})
+	require.ErrorIs(t, err, boom)
+}


### PR DESCRIPTION
Buffered created its buffer channel once at construction time and baked it into FromChannel, so a second consumption read the already-closed channel and silently returned an empty result. Convert Buffered to a self-contained provider whose channel/cancel/done state is created per Open, so double collection drains the source again.

While here, drop the Result{Err: io.EOF} sentinel: normal completion is now signalled by the buffering goroutine closing the channel (emit maps a closed channel to io.EOF), removing Buffered's dependency on the Result-unpacking indirection. Real upstream errors are still forwarded through the buffer, and the teardown cancel+join (source fully closed before Consume returns) is preserved.

Adds re-consumption tests (fresh, and after an early-terminated consumption). Existing prefetch, teardown-join, error, and empty-stream tests are unchanged and green under -race.