### PR TITLE
Add DoFirst: observational hook before all lifecycle Opens

### DIFF
--- a/docs/shpanstream-dofirst-design.md
+++ b/docs/shpanstream-dofirst-design.md
@@ -1,0 +1,117 @@
+# Design: `DoFirst` — observational hook before all lifecycle Opens
+
+*Response to a consumer request for a `WithPrependedLifecycle` API, motivated by a stream-metrics
+wrapper library that needs to measure a drain's full wall time. Decision: meet the need with a
+narrow observational hook instead of exposing lifecycle-order control.*
+
+## Problem
+
+An external wrapper cannot observe a drain's full wall time. `WithAdditionalLifecycle` appends
+and `doOpenStream` opens lifecycles in list order (both in `stream/shpan_stream.go`), so a
+wrapper-added Open always runs after every upstream Open.
+For DB-backed streams the real work (pool acquire, query, time-to-first-row) happens in the
+source's Open, so a metrics wrapper measures iteration time only. Additionally, when an upstream
+Open fails, an appended Open never ran, so a timer never armed: the wrapper counts an error (via
+`DoFinally`) but records no duration sample, breaking `count == successes + errors` invariants.
+
+## Why not `WithPrependedLifecycle`
+
+`doCloseSubStream` (`stream/shpan_stream.go`) closes in **forward** list order — same as open,
+not reverse. A prepended lifecycle therefore opens first *and closes first*, before the source
+closes. That is fine for a purely observational bracket, but the API cannot enforce
+"observational only": the natural misuse — prepending a resource lifecycle (pool handle, span,
+transaction) that the source depends on — looks correct at open time and is silently wrong at
+close time. An API whose safe use is a doc caveat is a footgun, and once shipped the close order
+cannot be fixed without breaking whoever relied on it. General prepend becomes legitimate only
+with reverse-order close (true bracket semantics), which is a global behavioral change nothing in
+the current use case requires.
+
+Precedent: Reactor solved this exact gap (`doOnSubscribe` fires too late to observe source
+subscription work) with the narrow `doFirst(Runnable)` — guaranteed to run before the source is
+subscribed, deliberately not a resource-holding lifecycle — never with user-controlled operator
+ordering.
+
+## API
+
+```go
+// DoFirst registers f to run at the start of every drain, before any lifecycle
+// element's Open (including the source's). Purely observational: f cannot fail
+// or abort the stream, and panics are recovered and logged (like DoFinally).
+// Multiple DoFirst hooks run in reverse declaration order (last declared, first run).
+// Pairs with DoFinally to bracket a drain's full wall time, including source Open.
+func (s Stream[T]) DoFirst(f func(ctx context.Context)) Stream[T]
+```
+
+Semantics:
+
+- **Position.** Prepends an internal lifecycle node, so its Open runs before all lifecycle
+  elements registered so far. Operators applied later append to the end, so the node stays first;
+  a later `DoFirst` prepends again, giving last-declared-first order (matches Reactor `doFirst`).
+- **Ctx.** `f` receives the drain's context (`ctxWithCancel` from `doOpenStream`), useful for
+  tracing.
+- **No error, no Close.** `f` returns nothing; the node's Close is a no-op. There is nothing to
+  misorder at teardown.
+- **Panic guard.** `f` runs under the same recover-and-`slog.Error` guard as `finallyNode.invoke`
+  so a buggy hook cannot crash the consumer.
+- **Open failure.** If a downstream (later-in-list) Open fails after `f` ran, existing rollback in
+  `doOpenStream` closes the node (no-op) and `fireFinallyHooksOnOpenFailure` still delivers the
+  error to `DoFinally` hooks — so a `DoFirst`-armed timer gets its duration sample on open
+  failure, restoring `duration_seconds_count == successes + errors`.
+- **Re-consumption.** Open fires per drain, so `f` runs again on each re-consumption.
+
+## Implementation
+
+One new method in `stream/do_first.go` (beside `do_finally.go`): prepend a panic-guarded
+observational node via
+`newStream(s.provider, append([]Lifecycle{node}, s.allLifecycleElement...))`.
+Sibling backing-array aliasing (two derived streams appending into the same spare-capacity slot)
+is guarded once at the chokepoint where the in-place append happens: `WithAdditionalLifecycle`
+clips its slice (`slices.Clip`) before appending, so every producer of a lifecycle slice —
+`DoFirst`, `DoFinally`, or a future operator — is covered without per-call-site defenses.
+The panic guard is shared with `DoFinally` (`invokeObservationalHook` in
+`stream/do_finally.go`). No changes to `doOpenStream`, `doCloseSubStream`, or
+`fireFinallyHooksOnOpenFailure`; all already handle a prepended element correctly.
+
+Customer usage (their `MeasureTimer` wrapper):
+
+```go
+func MeasureTimer[T any](s stream.Stream[T], t *obs.Timer, labels ...string) stream.Stream[T] {
+	var stop func()
+	return s.
+		DoFirst(func(context.Context) { stop = t.Start(labels...) }).
+		DoFinally(func(err error) {
+			if stop != nil {
+				stop()
+				stop = nil
+			}
+			t.ObserveErr(err, labels...)
+		})
+}
+```
+
+Note: the shared `stop` variable is scoped per wrapped stream, not per drain, so this pattern
+assumes the measured stream is drained at most once at a time. Streams are re-consumable values;
+draining the same wrapped stream from multiple goroutines concurrently is a data race on `stop`
+and misattributes timer samples. For concurrent drains, keep per-drain state instead (e.g. arm
+the timer inside the drain's own scope and wrap each drain separately).
+
+## Testing
+
+- Order: `DoFirst` hook runs before an existing lifecycle's Open (and before the source provider's
+  Open).
+- Open failure: with a failing source Open, the `DoFirst` hook ran and `DoFinally` fired with the
+  open error (the count-parity case).
+- Re-consumption: hook runs again on each drain.
+- Panic guard: a panicking hook does not fail the drain; stream completes normally.
+- Multiple hooks: two `DoFirst` calls run in reverse declaration order.
+- Downstream composition: `DoFirst` attached before further operators (e.g. `Filter`) still runs
+  first.
+
+## Alternatives rejected
+
+1. **`WithPrependedLifecycle`** — exposes ordering control with unsafe close semantics (above).
+2. **Prepend + reverse-order close** — clean bracket semantics but a global behavioral change to
+   every existing stream; revisit only if a customer needs a true resource bracket
+   (open-first/close-last).
+3. **Full `Tap`/`Observe` instrumentation operator** (Reactor `SignalListener` analog) — bigger
+   API surface; `DoFirst` + `DoFinally` + `Peek` already compose into it. YAGNI.

--- a/stream/do_finally.go
+++ b/stream/do_finally.go
@@ -97,12 +97,18 @@ func (n *finallyNode) fireOpenFailure(err error) {
 // invoke runs the observational callback under a panic guard so a buggy hook cannot crash the
 // consumer or leak through Open/Close.
 func (n *finallyNode) invoke(err error) {
+	invokeObservationalHook("DoFinally", func() { n.f(err) })
+}
+
+// invokeObservationalHook runs an observational user hook (DoFirst/DoFinally) under a panic guard
+// so a buggy hook cannot crash the consumer or leak a panic through Open/Close.
+func invokeObservationalHook(hookName string, f func()) {
 	defer func() {
 		if rvr := recover(); rvr != nil {
-			slog.Error(fmt.Sprintf("DoFinally hook panicked: %v\n%s", rvr, debug.Stack()))
+			slog.Error(fmt.Sprintf("%s hook panicked: %v\n%s", hookName, rvr, debug.Stack()))
 		}
 	}()
-	n.f(err)
+	f()
 }
 
 // fireFinallyHooksOnOpenFailure notifies any DoFinally hooks among a stream's lifecycle elements

--- a/stream/do_first.go
+++ b/stream/do_first.go
@@ -1,0 +1,26 @@
+package stream
+
+import (
+	"context"
+)
+
+// DoFirst registers f to run at the start of every drain, before any lifecycle element's Open
+// (including the source's). It is purely observational: f cannot fail or abort the stream, and a
+// panic in f is recovered and logged (like DoFinally). Multiple DoFirst hooks run in reverse
+// declaration order (last declared, first run).
+//
+// Pairs with DoFinally to bracket a drain's full wall time: DoFirst fires before upstream open
+// work (e.g. issuing a DB query), and DoFinally fires with the terminal outcome — including when
+// an upstream Open fails, so a DoFirst-armed timer still gets its duration sample.
+func (s Stream[T]) DoFirst(f func(ctx context.Context)) Stream[T] {
+	return newStream(
+		s.provider,
+		append([]Lifecycle{NewLifecycle(
+			func(ctx context.Context) error {
+				invokeObservationalHook("DoFirst", func() { f(ctx) })
+				return nil
+			},
+			nil,
+		)}, s.allLifecycleElement...),
+	)
+}

--- a/stream/do_first_test.go
+++ b/stream/do_first_test.go
@@ -1,0 +1,91 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoFirst_RunsBeforeSourceOpen(t *testing.T) {
+	var order []string
+
+	out, err := Just(1, 2, 3).
+		WithAdditionalLifecycle(NewLifecycle(
+			func(ctx context.Context) error { order = append(order, "source-open"); return nil },
+			func() { order = append(order, "source-close") },
+		)).
+		DoFirst(func(context.Context) { order = append(order, "first") }).
+		Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, out)
+	require.Equal(t, []string{"first", "source-open", "source-close"}, order)
+}
+
+func TestDoFirst_OpenFailureHookRanAndDoFinallyGetsError(t *testing.T) {
+	boom := errors.New("boom")
+	var firstCalls, finallyCalls int
+	var got error
+
+	_, err := Error[int](boom).
+		DoFirst(func(context.Context) { firstCalls++ }).
+		DoFinally(func(e error) { finallyCalls++; got = e }).
+		Collect(context.Background())
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, boom)
+	require.Equal(t, 1, firstCalls, "timer must be armed even when source Open fails")
+	require.Equal(t, 1, finallyCalls)
+	require.ErrorIs(t, got, boom)
+}
+
+func TestDoFirst_FiresPerConsumption(t *testing.T) {
+	var calls int
+	s := Just(1).DoFirst(func(context.Context) { calls++ })
+
+	_, err := s.Collect(context.Background())
+	require.NoError(t, err)
+	_, err = s.Collect(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, 2, calls)
+}
+
+func TestDoFirst_PanickingHookDoesNotFailDrain(t *testing.T) {
+	out, err := Just(1, 2).
+		DoFirst(func(context.Context) { panic("kaboom") }).
+		Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, out)
+}
+
+func TestDoFirst_MultipleHooksLastDeclaredRunsFirst(t *testing.T) {
+	var order []string
+
+	_, err := Just(1).
+		DoFirst(func(context.Context) { order = append(order, "a") }).
+		DoFirst(func(context.Context) { order = append(order, "b") }).
+		Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"b", "a"}, order)
+}
+
+func TestDoFirst_StaysFirstUnderDownstreamOperators(t *testing.T) {
+	var order []string
+
+	s := Just(1, 2, 3).
+		DoFirst(func(context.Context) { order = append(order, "first") }).
+		WithAdditionalLifecycle(NewLifecycle(
+			func(ctx context.Context) error { order = append(order, "later-open"); return nil },
+			nil,
+		))
+	out, err := s.Filter(func(i int) bool { return i > 1 }).Collect(context.Background())
+
+	require.NoError(t, err)
+	require.Equal(t, []int{2, 3}, out)
+	require.Equal(t, []string{"first", "later-open"}, order)
+}

--- a/stream/shpan_stream.go
+++ b/stream/shpan_stream.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"runtime/debug"
+	"slices"
 
 	"github.com/shpandrak/shpanstream"
 	"github.com/shpandrak/shpanstream/internal/util"
@@ -293,7 +294,10 @@ func (s Stream[T]) IsEmpty(ctx context.Context) (bool, error) {
 }
 
 func (s Stream[T]) WithAdditionalLifecycle(lch Lifecycle) Stream[T] {
-	return newStream(s.provider, append(s.allLifecycleElement, lch))
+	// Clip so the append always reallocates: s.allLifecycleElement may have spare capacity
+	// shared with sibling streams derived from the same parent, and an in-place append would
+	// overwrite their appended element.
+	return newStream(s.provider, append(slices.Clip(s.allLifecycleElement), lch))
 }
 
 func doOpenStream[T any](ctx context.Context, s Stream[T]) (context.CancelFunc, error) {

--- a/stream/shpan_stream_test.go
+++ b/stream/shpan_stream_test.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"context"
 	"testing"
 
 	"github.com/shpandrak/shpanstream/lazy"
@@ -44,4 +45,28 @@ func TestStream_Filter(t *testing.T) {
 		4,
 	)
 
+}
+
+func TestWithAdditionalLifecycle_SiblingStreamsDoNotShareBackingArray(t *testing.T) {
+	// Grow the lifecycle slice until it has spare capacity, then derive two sibling
+	// streams from it: each sibling's appended element must land in its own backing
+	// array, not overwrite the other's.
+	base := Just(1).
+		WithAdditionalLifecycle(NewLifecycle(nil, nil)).
+		WithAdditionalLifecycle(NewLifecycle(nil, nil))
+
+	var aOpened, bOpened bool
+	sa := base.WithAdditionalLifecycle(NewLifecycle(
+		func(context.Context) error { aOpened = true; return nil },
+		nil,
+	))
+	sb := base.WithAdditionalLifecycle(NewLifecycle(
+		func(context.Context) error { bOpened = true; return nil },
+		nil,
+	))
+
+	require.Equal(t, []int{1}, sa.MustCollect())
+	require.Equal(t, []int{1}, sb.MustCollect())
+	require.True(t, aOpened, "sibling A's lifecycle was overwritten by sibling B's append")
+	require.True(t, bOpened)
 }


### PR DESCRIPTION
Streams could not observe a drain's full wall time from outside: WithAdditionalLifecycle appends, so an observer's Open runs after every upstream Open (missing e.g. DB pool acquire + query time), and when an upstream Open fails the appended Open never ran, so a timer never armed and the histogram count diverged from successes + errors.

DoFirst prepends a purely observational lifecycle node (panic guard shared with DoFinally via invokeObservationalHook) so its hook runs before all Opens, including the source's, and pairs with DoFinally to bracket the whole drain. Deliberately narrower than the requested WithPrependedLifecycle: lifecycles close in forward order, so general prepend control would tear down a prepended resource before the source's Close — see docs/shpanstream-dofirst-design.md.

Also fixes a latent sibling-aliasing bug surfaced while reviewing this change: WithAdditionalLifecycle appended in place, so two siblings derived from the same parent whose lifecycle slice had spare capacity (e.g. built by DoFinally's clone, which does not guarantee cap == len) could share a backing-array slot and silently overwrite each other's lifecycle element. WithAdditionalLifecycle now clips before appending, guarding every producer of a lifecycle slice at the single in-place append chokepoint; a regression test reproduces the sibling overwrite.