### PR TITLE
Report recovered pipeline panics to DoFinally hooks

### DIFF
--- a/docs/shpanstream-concurrent-panic-followup.md
+++ b/docs/shpanstream-concurrent-panic-followup.md
@@ -1,0 +1,61 @@
+# Follow-up: panics on goroutine-driven stream paths crash the process
+
+*Found while fixing the DoFinally pipeline-panic reporting (hooks fired nil for a recovered
+pipeline panic); deliberately split out of that fix. Reproduced on master, 2026-07-02.*
+
+## Problem
+
+Two options drive the pipeline from their own goroutines, and neither recovers panics there —
+so a pipeline panic that the sequential consume paths would recover and return as an error
+instead kills the whole process:
+
+- `consumeConcurrently` (`stream/shpan_stream_concurrent.go`): the provider runs in a producer
+  goroutine and the consumer callback runs in worker goroutines, neither with a `recover`.
+- `MapConcurrently` / `WithConcurrentMapOption` (`stream/concurrent_stream.go`): the source
+  provider runs in a reader goroutine and the mapper runs in worker goroutines, neither with a
+  `recover`. Reproduced: a panicking upstream mapper consumed through
+  `MapWithErrAndCtx(..., WithConcurrentMapOption(2))` crashes the process; a `DoFinally` node in
+  between records the panic (its recover-record-repanic guard) but the re-raised panic escapes
+  the reader goroutine before anything can observe it.
+
+For `consumeConcurrently` specifically:
+
+- **A pipeline panic (e.g. panicking mapper) kills the whole process.** Reproduced: unrecovered
+  panic in the producer goroutine at `shpan_stream_concurrent.go:94`.
+- **Worse, there is a race where the caller sees success first.** The panicking producer's deferred
+  `close(itemChan)` / `close(producerDone)` run during unwinding, letting the workers drain, the
+  `wg.Wait()` return, and `Consume` return `err == nil` — moments before the runtime crashes the
+  process on the still-unwinding panic.
+- A consumer-callback panic in a worker goroutine crashes the process the same way.
+
+This is inconsistent with the sequential path, which recovers both kinds of panics and returns
+them as errors.
+
+## Planned fix
+
+`consumeConcurrently`:
+
+- Producer goroutine: deferred `recover` that converts the panic via `recoveredPanicToError`
+  (added in the DoFinally fix, `stream/shpan_stream.go`) and sends it on `itemChan` as a
+  `Result{Err: ...}`, so it flows through `setErr` and is returned as `firstErr`. The DoFinally
+  provider wrapper already records the panic before it unwinds, so hooks report it consistently.
+- Worker goroutines: deferred `recover` feeding `setErr` with the converted error (consumer-side
+  failure — DoFinally hooks must still fire `nil`, matching the sequential boundary).
+
+`MapConcurrently` / `WithConcurrentMapOption` (`stream/concurrent_stream.go`):
+
+- Reader and mapper-worker goroutines: deferred `recover` converting the panic into an error
+  forwarded through the existing error channel/first-error machinery, so it surfaces as the
+  provider error of the concurrent map stage (a pipeline failure — DoFinally hooks downstream of
+  the stage should observe it).
+
+## Tests to add
+
+- Pipeline panic under concurrent consume: process survives, caller gets the recovered error,
+  DoFinally hook gets the equivalent error.
+- Consumer-callback panic in a worker: process survives, caller gets the recovered error,
+  DoFinally hook fires `nil`.
+- No success-before-crash race: the caller must never observe `err == nil` for a panicking drain.
+- Pipeline panic under `WithConcurrentMapOption`: process survives, caller gets the recovered
+  error, DoFinally hooks (both upstream-of-the-stage-with-panic-downstream and downstream of the
+  stage) observe their locality-correct outcome.

--- a/stream/do_finally.go
+++ b/stream/do_finally.go
@@ -21,7 +21,13 @@ import (
 //	              before the already-opened upstream siblings are torn down, since the open error
 //	              must win over the rollback close. External context cancellation surfaces as the
 //	              context error (use errors.Is(err, context.Canceled) / context.DeadlineExceeded to
-//	              detect it).
+//	              detect it). A panic raised inside the pipeline upstream of this node (e.g. a
+//	              panicking mapper) is a drain failure and is reported as the recovered panic
+//	              error — equivalent to (wrapping the same panicked value as) the error the
+//	              consumer returns to the caller, though not the same error instance. This holds
+//	              on the sequential consume paths; options that drive the pipeline from their own
+//	              goroutines (WithConcurrentMapOption, WithConcurrentConsumeOption) do not yet
+//	              recover pipeline panics at all — see docs/shpanstream-concurrent-panic-followup.md.
 //
 // DoFinally is local and compositional (like the Lifecycle Open/Close hooks): it observes this node
 // and everything upstream feeding it, wherever the node sits — including as a sub-stream inside a
@@ -40,13 +46,34 @@ import (
 func (s Stream[T]) DoFinally(f func(err error)) Stream[T] {
 	n := &finallyNode{f: f}
 	return newStream(
-		func(ctx context.Context) (T, error) {
-			v, err := s.provider(ctx)
+		func(ctx context.Context) (v T, err error) {
+			// A panic unwinding through this frame necessarily originated in the node's own
+			// subtree (upstream), so it is this node's terminal outcome: record it and re-panic,
+			// letting the consumer's recover turn it into the caller's error. Consumer-callback
+			// and downstream-operator panics never pass through this frame, so the consumer-side
+			// boundary and locality rules are preserved for free. The completed flag (rather than
+			// recover() != nil) is what detects unwinding, so a legacy panic(nil) under
+			// GODEBUG=panicnil=1 — where recover() returns nil and thereby cancels the panic —
+			// surfaces as a provider error instead of a spurious zero element.
+			completed := false
+			defer func() {
+				if completed {
+					return
+				}
+				if rvr := recover(); rvr != nil {
+					n.recordedErr = recoveredPanicToError(rvr)
+					panic(rvr)
+				}
+				err = recoveredPanicToError(nil)
+				n.recordedErr = err
+			}()
+			v, err = s.provider(ctx)
 			// Record the terminal error the node's own subtree produced, so the Close hook can
 			// report it locally. io.EOF is normal completion, not an error.
 			if err != nil && err != io.EOF {
 				n.recordedErr = err
 			}
+			completed = true
 			return v, err
 		},
 		append(slices.Clone(s.allLifecycleElement), n),

--- a/stream/do_finally.go
+++ b/stream/do_finally.go
@@ -28,6 +28,8 @@ import (
 //	              on the sequential consume paths; options that drive the pipeline from their own
 //	              goroutines (WithConcurrentMapOption, WithConcurrentConsumeOption) do not yet
 //	              recover pipeline panics at all — see docs/shpanstream-concurrent-panic-followup.md.
+//	              A runtime.Goexit unwinding through the pipeline (e.g. t.FailNow inside a mapper)
+//	              abandons the drain rather than failing it: f fires with err == nil.
 //
 // DoFinally is local and compositional (like the Lifecycle Open/Close hooks): it observes this node
 // and everything upstream feeding it, wherever the node sits — including as a sub-stream inside a
@@ -45,35 +47,41 @@ import (
 // Consume/Collect/Reduce.
 func (s Stream[T]) DoFinally(f func(err error)) Stream[T] {
 	n := &finallyNode{f: f}
+	// guardedPull pulls one element from upstream under the node's panic guard. A panic unwinding
+	// through this frame necessarily originated in the node's own subtree (upstream), so it is
+	// this node's terminal outcome: record it and re-panic, letting the consumer's recover turn it
+	// into the caller's error. Consumer-callback and downstream-operator panics never pass through
+	// this frame, so the consumer-side boundary and locality rules are preserved for free. The
+	// completed flag (rather than recover() != nil) is what detects unwinding, so a legacy
+	// panic(nil) under GODEBUG=panicnil=1 — where recover() returns nil and thereby cancels the
+	// panic — surfaces as a provider error instead of a spurious zero element. That branch sets
+	// only err, never n.recordedErr: recording happens in the provider below, which only executes
+	// on a genuine return. A runtime.Goexit (e.g. t.FailNow in a mapper) trips the same branch but
+	// never returns to the provider, so an abandoned drain records nothing and the hook fires nil.
+	guardedPull := func(ctx context.Context) (v T, err error) {
+		completed := false
+		defer func() {
+			if completed {
+				return
+			}
+			if rvr := recover(); rvr != nil {
+				n.recordedErr = recoveredPanicToError(rvr)
+				panic(rvr)
+			}
+			err = recoveredPanicToError(nil)
+		}()
+		v, err = s.provider(ctx)
+		completed = true
+		return v, err
+	}
 	return newStream(
-		func(ctx context.Context) (v T, err error) {
-			// A panic unwinding through this frame necessarily originated in the node's own
-			// subtree (upstream), so it is this node's terminal outcome: record it and re-panic,
-			// letting the consumer's recover turn it into the caller's error. Consumer-callback
-			// and downstream-operator panics never pass through this frame, so the consumer-side
-			// boundary and locality rules are preserved for free. The completed flag (rather than
-			// recover() != nil) is what detects unwinding, so a legacy panic(nil) under
-			// GODEBUG=panicnil=1 — where recover() returns nil and thereby cancels the panic —
-			// surfaces as a provider error instead of a spurious zero element.
-			completed := false
-			defer func() {
-				if completed {
-					return
-				}
-				if rvr := recover(); rvr != nil {
-					n.recordedErr = recoveredPanicToError(rvr)
-					panic(rvr)
-				}
-				err = recoveredPanicToError(nil)
-				n.recordedErr = err
-			}()
-			v, err = s.provider(ctx)
+		func(ctx context.Context) (T, error) {
+			v, err := guardedPull(ctx)
 			// Record the terminal error the node's own subtree produced, so the Close hook can
 			// report it locally. io.EOF is normal completion, not an error.
 			if err != nil && err != io.EOF {
 				n.recordedErr = err
 			}
-			completed = true
 			return v, err
 		},
 		append(slices.Clone(s.allLifecycleElement), n),

--- a/stream/do_finally_test.go
+++ b/stream/do_finally_test.go
@@ -299,12 +299,12 @@ func TestDoFinally_MultipleHooksAllFire(t *testing.T) {
 	require.ErrorIs(t, b, boom)
 }
 
-// A panic inside the pipeline is recovered by the consumer and surfaces as its returned error;
-// it does not travel back through the provider as a value, so DoFinally reports nil (documented
-// limitation, same bucket as consumer-side failures). This test pins that behavior.
-func TestDoFinally_PipelinePanicFiresNil(t *testing.T) {
+// A panic inside the pipeline (upstream of the hook) is a drain failure: the consumer recovers it
+// and returns it as an error, and DoFinally observes an equivalent error (wrapping the same
+// panicked value) — the hook and the caller must agree that the drain failed.
+func TestDoFinally_PipelinePanicFiresRecoveredError(t *testing.T) {
 	var calls int
-	var got error = errors.New("sentinel-not-called")
+	var got error
 
 	_, err := Map(Just(1, 2, 3), func(i int) int {
 		if i == 2 {
@@ -315,7 +315,115 @@ func TestDoFinally_PipelinePanicFiresNil(t *testing.T) {
 		DoFinally(func(e error) { calls++; got = e }).
 		Collect(context.Background())
 
-	require.Error(t, err) // consumer still surfaces the panic as an error
+	require.Error(t, err)
+	require.ErrorContains(t, err, "pipeline boom")
 	require.Equal(t, 1, calls)
-	require.NoError(t, got) // ... but DoFinally does not observe it
+	require.Error(t, got)
+	require.ErrorContains(t, got, "pipeline boom")
+}
+
+// A pipeline panic that wraps an error value must surface to the hook with the error chain intact.
+func TestDoFinally_PipelinePanicWithErrorValueFiresMatchingError(t *testing.T) {
+	boom := errors.New("boom")
+	var got error
+
+	_, err := Map(Just(1, 2, 3), func(i int) int {
+		if i == 2 {
+			panic(boom)
+		}
+		return i
+	}).
+		DoFinally(func(e error) { got = e }).
+		Collect(context.Background())
+
+	require.ErrorIs(t, err, boom)
+	require.ErrorIs(t, got, boom)
+}
+
+// DoFinally is local: a panic in an operator applied *downstream* of the hook tears the hook's
+// subtree down cleanly, so the hook fires nil — same rule as downstream errors.
+func TestDoFinally_DownstreamPanicFiresNil(t *testing.T) {
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	_, err := Map(
+		Just(1, 2, 3).DoFinally(func(e error) { calls++; got = e }),
+		func(i int) int {
+			if i == 2 {
+				panic("downstream boom")
+			}
+			return i
+		},
+	).Collect(context.Background())
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
+}
+
+// A consumer-callback panic is a delivery failure, not a pipeline failure: the caller gets the
+// recovered error, the hook fires nil — same boundary as consumer-callback errors.
+func TestDoFinally_ConsumerCallbackPanicFiresNil(t *testing.T) {
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	err := Just(1, 2, 3).
+		DoFinally(func(e error) { calls++; got = e }).
+		Consume(context.Background(), func(i int) {
+			if i == 2 {
+				panic("consumer boom")
+			}
+		})
+
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
+}
+
+// Under the legacy GODEBUG=panicnil=1 mode, recover() returns nil for panic(nil). The DoFinally
+// provider guard must not turn such a panic into a spurious zero element and a clean completion;
+// it surfaces as a pipeline error to both the caller and the hook.
+func TestDoFinally_LegacyPanicNilDoesNotCorruptStream(t *testing.T) {
+	t.Setenv("GODEBUG", "panicnil=1")
+
+	var got error
+	out, err := Map(Just(1, 2, 3), func(i int) int {
+		if i == 2 {
+			panic(nil)
+		}
+		return i
+	}).
+		DoFinally(func(e error) { got = e }).
+		Collect(context.Background())
+
+	require.Error(t, err)
+	require.NotContains(t, out, 0) // no spurious zero element
+	require.Error(t, got)
+}
+
+// Re-consuming after a panicking drain must reset the hook's state: the second drain reports its
+// own outcome, not the first drain's panic.
+func TestDoFinally_ReconsumeAfterPanicFiresOwnOutcome(t *testing.T) {
+	var outcomes []error
+	shouldPanic := true
+
+	s := Map(Just(1, 2, 3), func(i int) int {
+		if shouldPanic && i == 2 {
+			panic("first drain boom")
+		}
+		return i
+	}).DoFinally(func(e error) { outcomes = append(outcomes, e) })
+
+	_, err := s.Collect(context.Background())
+	require.Error(t, err)
+
+	shouldPanic = false
+	out, err := s.Collect(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, out)
+
+	require.Len(t, outcomes, 2)
+	require.Error(t, outcomes[0])
+	require.ErrorContains(t, outcomes[0], "first drain boom")
+	require.NoError(t, outcomes[1])
 }

--- a/stream/do_finally_test.go
+++ b/stream/do_finally_test.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -426,4 +427,29 @@ func TestDoFinally_ReconsumeAfterPanicFiresOwnOutcome(t *testing.T) {
 	require.Error(t, outcomes[0])
 	require.ErrorContains(t, outcomes[0], "first drain boom")
 	require.NoError(t, outcomes[1])
+}
+
+// runtime.Goexit unwinding through the pipeline (most commonly t.FailNow/t.Fatal inside a mapper
+// or source) is not a pipeline panic: the drain is abandoned, not failed, so the hook must fire
+// nil — not a fabricated recovered-panic error.
+func TestDoFinally_GoexitFiresNil(t *testing.T) {
+	var calls int
+	var got error = errors.New("sentinel-not-called")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = Map(Just(1, 2, 3), func(i int) int {
+			if i == 2 {
+				runtime.Goexit()
+			}
+			return i
+		}).
+			DoFinally(func(e error) { calls++; got = e }).
+			Collect(context.Background())
+	}()
+	<-done
+
+	require.Equal(t, 1, calls)
+	require.NoError(t, got)
 }

--- a/stream/shpan_stream.go
+++ b/stream/shpan_stream.go
@@ -101,21 +101,36 @@ func recoveredPanicToError(rvr any) error {
 	return fmt.Errorf("stream recovered error value: %v", rvr)
 }
 
-// recoverStreamPanic is the consumer-boundary panic guard shared by the sequential and concurrent
-// consume paths: it logs the recovered panic with its stack and converts it into the error the
-// consumer returns. It must be invoked directly by defer (recover only works one frame deep).
-func recoverStreamPanic(err *error) {
-	if rvr := recover(); rvr != nil {
-		slog.Error(fmt.Sprintf("Panic recovered: %v\n%s", rvr, debug.Stack()))
-		*err = recoveredPanicToError(rvr)
-	}
+// consumeWithPanicGuard is the consumer-boundary panic guard shared by the sequential and
+// concurrent consume paths: a panic unwinding out of body is logged with its stack and converted
+// into the error the consumer returns. The completed flag (rather than recover() != nil) is what
+// detects unwinding, so a legacy panic(nil) under GODEBUG=panicnil=1 — where recover() returns nil
+// and thereby cancels the panic — surfaces as an error instead of a clean, silently truncated
+// drain. A runtime.Goexit trips the flag too, but the error it fabricates is only assigned to a
+// return value Goexit discards, so it stays harmless.
+func consumeWithPanicGuard(body func() error) (err error) {
+	completed := false
+	defer func() {
+		if completed {
+			return
+		}
+		if rvr := recover(); rvr != nil {
+			slog.Error(fmt.Sprintf("Panic recovered: %v\n%s", rvr, debug.Stack()))
+			err = recoveredPanicToError(rvr)
+			return
+		}
+		err = recoveredPanicToError(nil)
+	}()
+	err = body()
+	completed = true
+	return err
 }
 
 // ConsumeWithErrAndCtx consumes the entire stream and applies the provided function to each element (sometimes named ForEach).
 // Allow returning an error from the function to stop the pipeline,
 // passing through the context allowing the function to gracefully cancel
 // It returns an error if the stream materialization fails in any stage of the pipeline
-func (s Stream[T]) ConsumeWithErrAndCtx(ctx context.Context, f func(ctx context.Context, value T) error, options ...ConsumeOption) (err error) {
+func (s Stream[T]) ConsumeWithErrAndCtx(ctx context.Context, f func(ctx context.Context, value T) error, options ...ConsumeOption) error {
 	// Check for the concurrent option
 	for _, opt := range options {
 		switch cOpt := opt.(type) {
@@ -123,41 +138,41 @@ func (s Stream[T]) ConsumeWithErrAndCtx(ctx context.Context, f func(ctx context.
 			return s.consumeConcurrently(ctx, cOpt.concurrency, f)
 		}
 	}
-	// Adding a panic recovery to avoid leaking resources and allow returning an error via panic instead of returning it
-	defer recoverStreamPanic(&err)
-
-	cancelFunc, errVar := doOpenStream[T](ctx, s)
-	if errVar != nil {
-		return fmt.Errorf("failed to open stream: %w", errVar)
-	}
-
-	// If we reach here, all lifecycle elements have been opened successfully
-	// We can defer closing them until the end of the function
-	defer func() {
-		doCloseSubStream(s)
-		cancelFunc()
-	}()
-
-	for {
-
-		// Make sure to check if the context is done before trying to get the next item
-		if ctx.Err() != nil {
-			// If the context is cancelled, we need to close all lifecycle elements
-			// return
-			return ctx.Err()
-		}
-		v, errVar := s.provider(ctx)
+	// The panic guard avoids leaking resources and allows returning an error via panic instead of returning it
+	return consumeWithPanicGuard(func() error {
+		cancelFunc, errVar := doOpenStream[T](ctx, s)
 		if errVar != nil {
-			if errVar == io.EOF {
-				return nil
+			return fmt.Errorf("failed to open stream: %w", errVar)
+		}
+
+		// If we reach here, all lifecycle elements have been opened successfully
+		// We can defer closing them until the end of the function
+		defer func() {
+			doCloseSubStream(s)
+			cancelFunc()
+		}()
+
+		for {
+
+			// Make sure to check if the context is done before trying to get the next item
+			if ctx.Err() != nil {
+				// If the context is cancelled, we need to close all lifecycle elements
+				// return
+				return ctx.Err()
 			}
-			return errVar
+			v, errVar := s.provider(ctx)
+			if errVar != nil {
+				if errVar == io.EOF {
+					return nil
+				}
+				return errVar
+			}
+			errVar = f(ctx, v)
+			if errVar != nil {
+				return errVar
+			}
 		}
-		errVar = f(ctx, v)
-		if errVar != nil {
-			return errVar
-		}
-	}
+	})
 }
 
 func (s Stream[T]) FindFirst() lazy.Lazy[T] {

--- a/stream/shpan_stream.go
+++ b/stream/shpan_stream.go
@@ -92,6 +92,25 @@ func (s Stream[T]) ConsumeWithErr(ctx context.Context, f func(T) error, options 
 	}, options...)
 }
 
+// recoveredPanicToError converts a recovered panic value into the error reported to callers and
+// DoFinally hooks, preserving the error chain when the panic value is an error.
+func recoveredPanicToError(rvr any) error {
+	if asErr, ok := rvr.(error); ok {
+		return fmt.Errorf("stream recovered error: %w", asErr)
+	}
+	return fmt.Errorf("stream recovered error value: %v", rvr)
+}
+
+// recoverStreamPanic is the consumer-boundary panic guard shared by the sequential and concurrent
+// consume paths: it logs the recovered panic with its stack and converts it into the error the
+// consumer returns. It must be invoked directly by defer (recover only works one frame deep).
+func recoverStreamPanic(err *error) {
+	if rvr := recover(); rvr != nil {
+		slog.Error(fmt.Sprintf("Panic recovered: %v\n%s", rvr, debug.Stack()))
+		*err = recoveredPanicToError(rvr)
+	}
+}
+
 // ConsumeWithErrAndCtx consumes the entire stream and applies the provided function to each element (sometimes named ForEach).
 // Allow returning an error from the function to stop the pipeline,
 // passing through the context allowing the function to gracefully cancel
@@ -105,18 +124,7 @@ func (s Stream[T]) ConsumeWithErrAndCtx(ctx context.Context, f func(ctx context.
 		}
 	}
 	// Adding a panic recovery to avoid leaking resources and allow returning an error via panic instead of returning it
-	defer func() {
-		if rvr := recover(); rvr != nil {
-			slog.Error(fmt.Sprintf("Panic recovered: %v\n%s", rvr, debug.Stack()))
-			asErr, ok := rvr.(error)
-			if ok {
-				err = fmt.Errorf("stream recovered error: %w", asErr)
-			} else {
-				err = fmt.Errorf("stream recovered error value: %v", rvr)
-			}
-
-		}
-	}()
+	defer recoverStreamPanic(&err)
 
 	cancelFunc, errVar := doOpenStream[T](ctx, s)
 	if errVar != nil {

--- a/stream/shpan_stream_concurrent.go
+++ b/stream/shpan_stream_concurrent.go
@@ -33,14 +33,18 @@ func (c *concurrentConsumeOption) consumeOptionName() string {
 // consumeConcurrently consumes the stream concurrently with the specified number of workers.
 // The consumer function is called concurrently, but the source stream is read sequentially.
 // Returns the first error encountered (either from reading the stream or from the consumer function).
-func (s Stream[T]) consumeConcurrently(ctx context.Context, concurrency int, f func(ctx context.Context, value T) error) (err error) {
+func (s Stream[T]) consumeConcurrently(ctx context.Context, concurrency int, f func(ctx context.Context, value T) error) error {
 	if concurrency <= 0 {
 		return fmt.Errorf("concurrency must be > 0")
 	}
 
-	// Adding a panic recovery to avoid leaking resources and allow returning an error via panic instead of returning it
-	defer recoverStreamPanic(&err)
+	// The panic guard avoids leaking resources and allows returning an error via panic instead of returning it
+	return consumeWithPanicGuard(func() error {
+		return s.doConsumeConcurrently(ctx, concurrency, f)
+	})
+}
 
+func (s Stream[T]) doConsumeConcurrently(ctx context.Context, concurrency int, f func(ctx context.Context, value T) error) error {
 	cancelFunc, errVar := doOpenStream[T](ctx, s)
 	if errVar != nil {
 		return fmt.Errorf("failed to open stream: %w", errVar)

--- a/stream/shpan_stream_concurrent.go
+++ b/stream/shpan_stream_concurrent.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
-	"runtime/debug"
 	"sync"
 
 	"github.com/shpandrak/shpanstream"
@@ -41,17 +39,7 @@ func (s Stream[T]) consumeConcurrently(ctx context.Context, concurrency int, f f
 	}
 
 	// Adding a panic recovery to avoid leaking resources and allow returning an error via panic instead of returning it
-	defer func() {
-		if rvr := recover(); rvr != nil {
-			slog.Error(fmt.Sprintf("Panic recovered: %v\n%s", rvr, debug.Stack()))
-			asErr, ok := rvr.(error)
-			if ok {
-				err = fmt.Errorf("stream recovered error: %w", asErr)
-			} else {
-				err = fmt.Errorf("stream recovered error value: %v", rvr)
-			}
-		}
-	}()
+	defer recoverStreamPanic(&err)
 
 	cancelFunc, errVar := doOpenStream[T](ctx, s)
 	if errVar != nil {

--- a/stream/shpan_stream_error_handling_test.go
+++ b/stream/shpan_stream_error_handling_test.go
@@ -29,6 +29,23 @@ func TestStream_PanicMap(t *testing.T) {
 
 }
 
+// Under the legacy GODEBUG=panicnil=1 mode, recover() returns nil for panic(nil) — and calling
+// recover() cancels the panic. The consumer-boundary guard must not let such a panic dissolve into
+// a clean, silently-truncated drain: the caller must get a pipeline error even when no DoFinally
+// node is present (the DoFinally provider guard covers this independently when one is).
+func TestStream_LegacyPanicNilSurfacesErrorToConsumer(t *testing.T) {
+	t.Setenv("GODEBUG", "panicnil=1")
+
+	out, err := Map(Just(1, 2, 3), func(i int) int {
+		if i == 2 {
+			panic(nil)
+		}
+		return i
+	}).Collect(context.Background())
+
+	require.Error(t, err, "legacy panic(nil) must surface as an error, not truncated success (got %v)", out)
+}
+
 func TestStream_ErrorFilter(t *testing.T) {
 	_, err := Just(1, 2, 3, 4, 5).
 		FilterWithErr(func(i int) (bool, error) {


### PR DESCRIPTION
## Summary

Makes `DoFinally` hooks observe pipeline panics, closing the one terminal outcome where the hook and the caller disagreed: a panicking drain previously surfaced as an error to the caller but as `nil` to the hook, so observability built on `DoFinally` recorded it as a clean completion.

- A panic upstream of a `DoFinally` node is recorded as the node's terminal error and re-panicked; the consumer's recover still produces the caller's error. Consumer-callback and downstream-operator panics never pass through the node's frame, so locality and the consumer-side boundary are preserved structurally.
- The panic-to-error conversion is shared (`recoveredPanicToError`), and the consumer boundary uses a common guard (`consumeWithPanicGuard`).

## Review fixes (second commit)

A high-effort multi-agent review of the first commit confirmed two defects, both fixed test-first:

1. **panicnil inconsistency** — the consume-boundary guard kept the bare `recover() != nil` pattern, so under `GODEBUG=panicnil=1` a pipeline `panic(nil)` with no `DoFinally` node dissolved into a clean, silently truncated drain (`out=[1], err=nil`). The boundary now uses the same completed-flag detection as the `DoFinally` guard. Pinned by `TestStream_LegacyPanicNilSurfacesErrorToConsumer`.
2. **Goexit misreport** — `runtime.Goexit` (e.g. `t.FailNow` in a mapper) tripped the guard's legacy-`panic(nil)` branch and fired hooks with a fabricated `stream recovered error value: <nil>`. The two cases are distinguished by where control goes next (a cancelled `panic(nil)` returns to the caller; Goexit never does), so error recording moved to the provider frame, which only executes on a genuine return. Pinned by `TestDoFinally_GoexitFiresNil`.

## Known gap (deliberately out of scope)

Goroutine-driven paths (`WithConcurrentMapOption`, `WithConcurrentConsumeOption`) still do not recover pipeline panics at all — a panic there crashes the process. Pre-existing on master, disclosed in the `DoFinally` doc comment, tracked in `docs/shpanstream-concurrent-panic-followup.md`.

## Testing

Full suite passes with `-race`; eight new tests pin the boundary semantics (upstream panic, panic-wrapped error chain, downstream panic, consumer-callback panic, legacy `panic(nil)` with and without a hook, re-consume reset, Goexit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)